### PR TITLE
Remove unused include

### DIFF
--- a/lib/log.c
+++ b/lib/log.c
@@ -41,9 +41,6 @@
 #include <stdarg.h>
 #include <string.h>
 #include <unistd.h>
-#ifdef __linux__
-#include <error.h>
-#endif /* __linux__ */
 #include <errno.h>
 
 #include "types.h"


### PR DESCRIPTION
Makes intel-cmt-cat more portable.