### PR TITLE
Fix the Makefiles to take LDFLAGS into account

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -48,6 +48,9 @@ CFLAGS = -pthread -I./ -D_GNU_SOURCE \
 ifneq ($(EXTRA_CFLAGS),)
 CFLAGS += $(EXTRA_CFLAGS)
 endif
+ifneq ($(EXTRA_LDFLAGS),)
+LDFLAGS += $(EXTRA_LDFLAGS)
+endif
 
 DOXY_DIRS = doc_api doc_lib
 

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -104,7 +104,7 @@ all: $(LIBNAME)
 
 $(LIBNAME): $(OBJS)
 ifeq ($(SHARED),y)
-	$(CC) -shared -Wl,-soname,$(LIB).so.$(SO_VERSION) -o $(LIBNAME) $^ -lc
+	$(CC) $(LDFLAGS) -shared -Wl,-soname,$(LIB).so.$(SO_VERSION) -o $(LIBNAME) $^ -lc
 	ln -f -s $(LIBNAME) $(LIB).so.$(SO_VERSION)
 	ln -f -s $(LIB).so.$(SO_VERSION) $(LIB).so
 else

--- a/pqos/Makefile
+++ b/pqos/Makefile
@@ -47,6 +47,9 @@ CFLAGS = -I$(LIBDIR) \
 ifneq ($(EXTRA_CFLAGS),)
 CFLAGS += $(EXTRA_CFLAGS)
 endif
+ifneq ($(EXTRA_LDFLAGS),)
+LDFLAGS += $(EXTRA_LDFLAGS)
+endif
 
 # ICC and GCC options
 ifeq ($(CC),icc)

--- a/rdtset/Makefile
+++ b/rdtset/Makefile
@@ -48,6 +48,9 @@ CFLAGS = -I$(LIBDIR) \
 ifneq ($(EXTRA_CFLAGS),)
 CFLAGS += $(EXTRA_CFLAGS)
 endif
+ifneq ($(EXTRA_LDFLAGS),)
+LDFLAGS += $(EXTRA_LDFLAGS)
+endif
 
 # ICC and GCC options
 ifeq ($(CC),icc)


### PR DESCRIPTION
Adding new EXTRA_LDFLAGS variable to be able to
add flags to LDFLAGS variable.

Fixing the libpqos Makefile to include LDFLAGS during the build.