### PR TITLE
Fix memory leak allocated by scandir

### DIFF
--- a/lib/os_monitoring.c
+++ b/lib/os_monitoring.c
@@ -556,17 +556,15 @@ tid_find(const pid_t pid, unsigned *tid_nr, pid_t **tid_map)
         tid = atoi(namelist[0]->d_name);
         if (pid != tid)
                 ret = tid_add(pid, tid_nr, tid_map);
-        else {
+        else
                 for (i = 0; i < num_tasks; i++) {
                         ret = tid_add((pid_t)atoi(namelist[i]->d_name),
                                       tid_nr, tid_map);
                         if (ret != PQOS_RETVAL_OK)
                                 break;
                 }
-       }
-       for (i = 0; i < num_tasks; i++) {
-       			free(namelist[i]);
-       }
+        for (i = 0; i < num_tasks; i++)
+                free(namelist[i]);
 
         free(namelist);
 

--- a/lib/os_monitoring.c
+++ b/lib/os_monitoring.c
@@ -556,13 +556,17 @@ tid_find(const pid_t pid, unsigned *tid_nr, pid_t **tid_map)
         tid = atoi(namelist[0]->d_name);
         if (pid != tid)
                 ret = tid_add(pid, tid_nr, tid_map);
-        else
+        else {
                 for (i = 0; i < num_tasks; i++) {
                         ret = tid_add((pid_t)atoi(namelist[i]->d_name),
                                       tid_nr, tid_map);
                         if (ret != PQOS_RETVAL_OK)
                                 break;
                 }
+       }
+       for (i = 0; i < num_tasks; i++) {
+       			free(namelist[i]);
+       }
 
         free(namelist);
 


### PR DESCRIPTION
Free the namelist items one by one
http://man7.org/linux/man-pages/man3/scandir.3.html#EXAMPLE
