### PR TITLE
Updated setup.py for unicode errors in build_py

### DIFF
--- a/lib/python/setup.py
+++ b/lib/python/setup.py
@@ -4,13 +4,13 @@ with open(u'README.txt', 'r') as long_desc_file:
     long_description = long_desc_file.read()
 
 setup(
-    name=u'pqos',
-    version=u'3.1.0',
-    maintainer=u'Intel',
-    maintainer_email=u'adrianx.boczkowski@intel.com',
-    packages=[u'pqos', u'pqos.test'],
-    url=u'https://github.com/intel/intel-cmt-cat',
-    license=u'BSD',
-    description=u'Python interface for PQoS library',
+    name='pqos',
+    version='3.1.0',
+    maintainer='Intel',
+    maintainer_email='adrianx.boczkowski@intel.com',
+    packages=['pqos', 'pqos.test'],
+    url='https://github.com/intel/intel-cmt-cat',
+    license='BSD',
+    description='Python interface for PQoS library',
     long_description=long_description,
 )


### PR DESCRIPTION
I was trying to install pqos' python module and I faced an error while installing it with unicode literals. When I removed the unicode literals the installation went fine. I have tested it over 'Sorbitol' aka 3.10.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changed setup.py to remove unicode literals for installation of python module.

## Affected parts
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- pqos module (python)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change is required because there are many developers who wants to interact with intel-rdt using python-wrapper

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I removed the literals and run "python setup.py install" using root user and the installation went fine over 3.10

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
