### PR TITLE
AMD v9 pull 2

### DIFF
--- a/examples/c/CAT_MBA/allocation_app_l3cat.c
+++ b/examples/c/CAT_MBA/allocation_app_l3cat.c
@@ -186,7 +186,7 @@ int main(int argc, char *argv[])
 	struct pqos_config cfg;
 	const struct pqos_cpuinfo *p_cpu = NULL;
 	const struct pqos_cap *p_cap = NULL;
-	unsigned sock_count, *p_sockets = NULL;
+	unsigned l3cat_id_count, *p_l3cat_ids = NULL;
 	int ret, exit_val = EXIT_SUCCESS;
 
 	memset(&cfg, 0, sizeof(cfg));
@@ -206,9 +206,9 @@ int main(int argc, char *argv[])
 		exit_val = EXIT_FAILURE;
 		goto error_exit;
 	}
-	/* Get CPU socket information to set COS */
-	p_sockets = pqos_cpu_get_sockets(p_cpu, &sock_count);
-	if (p_sockets == NULL) {
+	/* Get CPU l3cat id information to set COS */
+	p_l3cat_ids = pqos_cpu_get_l3cat_ids(p_cpu, &l3cat_id_count);
+	if (p_l3cat_ids == NULL) {
 		printf("Error retrieving CPU socket information!\n");
 		exit_val = EXIT_FAILURE;
 		goto error_exit;
@@ -217,7 +217,7 @@ int main(int argc, char *argv[])
 	allocation_get_input(argc, argv);
 	if (sel_l3ca_cos_num != 0) {
 		/* Set bit mask for COS allocation */
-		ret = set_allocation_class(sock_count, p_sockets);
+		ret = set_allocation_class(l3cat_id_count, p_l3cat_ids);
 		if (ret < 0) {
 			printf("Allocation configuration error!\n");
 			goto error_exit;
@@ -225,7 +225,7 @@ int main(int argc, char *argv[])
 		printf("Allocation configuration altered.\n");
 	}
 	/* Print COS and associated bit mask */
-	ret = print_allocation_config(sock_count, p_sockets);
+	ret = print_allocation_config(l3cat_id_count, p_l3cat_ids);
 	if (ret != PQOS_RETVAL_OK) {
 		printf("Allocation capability not detected!\n");
 		exit_val = EXIT_FAILURE;
@@ -236,7 +236,7 @@ int main(int argc, char *argv[])
 	ret = pqos_fini();
 	if (ret != PQOS_RETVAL_OK)
 		printf("Error shutting down PQoS library!\n");
-        if (p_sockets != NULL)
-                free(p_sockets);
+	if (p_l3cat_ids != NULL)
+		free(p_l3cat_ids);
 	return exit_val;
 }

--- a/examples/c/CAT_MBA/allocation_app_mba.c
+++ b/examples/c/CAT_MBA/allocation_app_mba.c
@@ -208,7 +208,7 @@ int main(int argc, char *argv[])
 	struct pqos_config cfg;
 	const struct pqos_cpuinfo *p_cpu = NULL;
 	const struct pqos_cap *p_cap = NULL;
-	unsigned sock_count, *p_sockets = NULL;
+	unsigned mba_id_count, *p_mba_ids = NULL;
 	int ret, exit_val = EXIT_SUCCESS;
 
 	memset(&cfg, 0, sizeof(cfg));
@@ -228,10 +228,10 @@ int main(int argc, char *argv[])
 		exit_val = EXIT_FAILURE;
 		goto error_exit;
 	}
-	/* Get CPU socket information to set COS */
-	p_sockets = pqos_cpu_get_sockets(p_cpu, &sock_count);
-	if (p_sockets == NULL) {
-		printf("Error retrieving CPU socket information!\n");
+	/* Get CPU mba_id information to set COS */
+	p_mba_ids = pqos_cpu_get_mba_ids(p_cpu, &mba_id_count);
+	if (p_mba_ids == NULL) {
+		printf("Error retrieving MBA ID information!\n");
 		exit_val = EXIT_FAILURE;
 		goto error_exit;
 	}
@@ -239,7 +239,7 @@ int main(int argc, char *argv[])
 	allocation_get_input(argc, argv);
 	if (sel_mba_cos_num != 0) {
 		/* Set delay value for MBA COS allocation */
-		ret = set_allocation_class(sock_count, p_sockets);
+		ret = set_allocation_class(mba_id_count, p_mba_ids);
 		if (ret < 0) {
 			printf("Allocation configuration error!\n");
 			goto error_exit;
@@ -247,7 +247,7 @@ int main(int argc, char *argv[])
 		printf("Allocation configuration altered.\n");
 	}
 	/* Print COS definition */
-	ret = print_allocation_config(p_cap, sock_count, p_sockets);
+	ret = print_allocation_config(p_cap, mba_id_count, p_mba_ids);
 	if (ret != PQOS_RETVAL_OK) {
 		printf("Allocation capability not detected!\n");
 		exit_val = EXIT_FAILURE;
@@ -258,7 +258,7 @@ int main(int argc, char *argv[])
 	ret = pqos_fini();
 	if (ret != PQOS_RETVAL_OK)
 		printf("Error shutting down PQoS library!\n");
-        if (p_sockets != NULL)
-                free(p_sockets);
+	if (p_mba_ids != NULL)
+		free(p_mba_ids);
 	return exit_val;
 }

--- a/examples/c/CAT_MBA/association_app.c
+++ b/examples/c/CAT_MBA/association_app.c
@@ -104,7 +104,7 @@ print_allocation_config(void)
 {
 	int ret;
 	unsigned i;
-	unsigned sock_count, *sockets = NULL;
+	unsigned l3cat_id_count, *l3cat_ids = NULL;
 	const struct pqos_cpuinfo *p_cpu = NULL;
 	const struct pqos_cap *p_cap = NULL;
 
@@ -114,25 +114,25 @@ print_allocation_config(void)
 		printf("Error retrieving PQoS capabilities!\n");
 		return;
 	}
-	/* Get CPU socket information to set COS */
-	sockets = pqos_cpu_get_sockets(p_cpu, &sock_count);
-	if (sockets == NULL) {
+	/* Get CPU l3cat_id information to set COS */
+	l3cat_ids = pqos_cpu_get_l3cat_ids(p_cpu, &l3cat_id_count);
+	if (l3cat_ids == NULL) {
 		printf("Error retrieving CPU socket information!\n");
 		return;
 	}
-	for (i = 0; i < sock_count; i++) {
+	for (i = 0; i < l3cat_id_count; i++) {
 		unsigned *lcores = NULL;
 		unsigned lcount = 0, n = 0;
 
-		lcores = pqos_cpu_get_cores(p_cpu, sockets[i], &lcount);
+		lcores = pqos_cpu_get_cores(p_cpu, l3cat_ids[i], &lcount);
 		if (lcores == NULL || lcount == 0) {
 			printf("Error retrieving core information!\n");
                         free(lcores);
-                        free(sockets);
+			free(l3cat_ids);
 			return;
 		}
 		printf("Core information for socket %u:\n",
-				sockets[i]);
+				l3cat_ids[i]);
 		for (n = 0; n < lcount; n++) {
 			unsigned class_id = 0;
 
@@ -146,7 +146,7 @@ print_allocation_config(void)
 		}
                 free(lcores);
 	}
-        free(sockets);
+	free(l3cat_ids);
 }
 /**
  * @brief Sets up association between cores and allocation classes of service

--- a/examples/c/CAT_MBA/reset_app.c
+++ b/examples/c/CAT_MBA/reset_app.c
@@ -121,7 +121,7 @@ int main(int argc, char *argv[])
         const struct pqos_cpuinfo *p_cpu = NULL;
         const struct pqos_cap *p_cap = NULL;
         const struct pqos_capability *cap_l3ca = NULL;
-        unsigned sock_count, *sockets = NULL;
+	unsigned l3cat_id_count, *l3cat_ids = NULL;
         int ret, exit_val = EXIT_SUCCESS;
 
 	memset(&cfg, 0, sizeof(cfg));
@@ -152,22 +152,22 @@ int main(int argc, char *argv[])
 		printf("CAT reset failed!\n");
 	else
 		printf("CAT reset successful\n");
-	/* Get CPU socket information to set COS */
-	sockets = pqos_cpu_get_sockets(p_cpu, &sock_count);
-        if (sockets == NULL) {
+	/* Get CPU l3cat_id information to set COS */
+	l3cat_ids = pqos_cpu_get_l3cat_ids(p_cpu, &l3cat_id_count);
+	if (l3cat_ids == NULL) {
                 printf("Error retrieving CPU socket information!\n");
                 exit_val = EXIT_FAILURE;
                 goto error_exit;
         }
 	(void) pqos_cap_get_type(p_cap, PQOS_CAP_TYPE_L3CA, &cap_l3ca);
 	/* Print COS and associated cores */
-	print_allocation_config(cap_l3ca, sock_count, sockets, p_cpu);
+	print_allocation_config(cap_l3ca, l3cat_id_count, l3cat_ids, p_cpu);
  error_exit:
 	/* reset and deallocate all the resources */
 	ret = pqos_fini();
 	if (ret != PQOS_RETVAL_OK)
 		printf("Error shutting down PQoS library!\n");
-        if (sockets != NULL)
-                free(sockets);
+	if (l3cat_ids != NULL)
+		free(l3cat_ids);
 	return exit_val;
 }

--- a/lib/allocation.c
+++ b/lib/allocation.c
@@ -852,7 +852,7 @@ hw_l2ca_get_min_cbm_bits(unsigned *min_cbm_bits)
 }
 
 int
-hw_mba_set(const unsigned socket,
+hw_mba_set(const unsigned mba_id,
            const unsigned num_cos,
            const struct pqos_mba *requested,
            struct pqos_mba *actual)
@@ -899,7 +899,7 @@ hw_mba_set(const unsigned socket,
         }
 
         ASSERT(m_cpu != NULL);
-        ret = pqos_cpu_get_one_core(m_cpu, socket, &core);
+	ret = pqos_cpu_get_one_by_mba_id(m_cpu, mba_id, &core);
         if (ret != PQOS_RETVAL_OK)
                 return ret;
 
@@ -936,7 +936,7 @@ hw_mba_set(const unsigned socket,
 }
 
 int
-hw_mba_get(const unsigned socket,
+hw_mba_get(const unsigned mba_id,
            const unsigned max_num_cos,
            unsigned *num_cos,
            struct pqos_mba *mba_tab)
@@ -959,7 +959,7 @@ hw_mba_get(const unsigned socket,
                 return PQOS_RETVAL_ERROR;
 
         ASSERT(m_cpu != NULL);
-        ret = pqos_cpu_get_one_core(m_cpu, socket, &core);
+	ret = pqos_cpu_get_one_by_mba_id(m_cpu, mba_id, &core);
         if (ret != PQOS_RETVAL_OK)
                 return ret;
 
@@ -1502,7 +1502,8 @@ hw_alloc_reset(const enum pqos_cdp_config l3_cdp_cfg,
 		for (j = 0; j < mba_id_num; j++) {
                         unsigned core = 0;
 
-			ret = pqos_cpu_get_one_core(m_cpu, mba_ids[j], &core);
+			ret = pqos_cpu_get_one_by_mba_id(m_cpu, mba_ids[j],
+							 &core);
                         if (ret != PQOS_RETVAL_OK)
                                 goto pqos_alloc_reset_exit;
 

--- a/lib/allocation.c
+++ b/lib/allocation.c
@@ -298,7 +298,7 @@ pqos_alloc_fini(void)
  */
 
 int
-hw_l3ca_set(const unsigned socket,
+hw_l3ca_set(const unsigned l3cat_id,
             const unsigned num_ca,
             const struct pqos_l3ca *ca)
 {
@@ -325,7 +325,7 @@ hw_l3ca_set(const unsigned socket,
                 return ret;
 
         ASSERT(m_cpu != NULL);
-        ret = pqos_cpu_get_one_core(cpu, socket, &core);
+	ret = pqos_cpu_get_one_by_l3cat_id(cpu, l3cat_id, &core);
         if (ret != PQOS_RETVAL_OK)
                 return ret;
 
@@ -374,7 +374,7 @@ hw_l3ca_set(const unsigned socket,
 }
 
 int
-hw_l3ca_get(const unsigned socket,
+hw_l3ca_get(const unsigned l3cat_id,
             const unsigned max_num_ca,
             unsigned *num_ca,
             struct pqos_l3ca *ca)
@@ -405,7 +405,7 @@ hw_l3ca_get(const unsigned socket,
                 return PQOS_RETVAL_ERROR;
 
         ASSERT(m_cpu != NULL);
-        ret = pqos_cpu_get_one_core(m_cpu, socket, &core);
+	ret = pqos_cpu_get_one_by_l3cat_id(m_cpu, l3cat_id, &core);
         if (ret != PQOS_RETVAL_OK)
                 return ret;
 
@@ -1170,23 +1170,23 @@ hw_alloc_release(const unsigned *core_array,
  * @retval PQOS_RETVAL_ERROR on failure, MSR read/write error
  */
 static int
-l3cdp_enable(const unsigned sockets_num,
-           const unsigned *sockets,
-           const int enable)
+l3cdp_enable(const unsigned l3cat_id_num,
+	     const unsigned *l3cat_ids,
+	     const int enable)
 {
         unsigned j = 0;
 
-        ASSERT(sockets_num > 0 && sockets != NULL);
+	ASSERT(l3cat_id_num > 0 && l3cat_ids != NULL);
 
         LOG_INFO("%s L3 CDP across sockets...\n",
                  (enable) ? "Enabling" : "Disabling");
 
-        for (j = 0; j < sockets_num; j++) {
+	for (j = 0; j < l3cat_id_num; j++) {
                 uint64_t reg = 0;
                 unsigned core = 0;
                 int ret = PQOS_RETVAL_OK;
 
-                ret = pqos_cpu_get_one_core(m_cpu, sockets[j], &core);
+		ret = pqos_cpu_get_one_by_l3cat_id(m_cpu, l3cat_ids[j], &core);
                 if (ret != PQOS_RETVAL_OK)
                         return ret;
 
@@ -1446,7 +1446,9 @@ hw_alloc_reset(const enum pqos_cdp_config l3_cdp_cfg,
 		for (j = 0; j < l3cat_id_num; j++) {
                         unsigned core = 0;
 
-			ret = pqos_cpu_get_one_core(m_cpu, l3cat_ids[j], &core);
+			ret = pqos_cpu_get_one_by_l3cat_id(m_cpu,
+							   l3cat_ids[j],
+							   &core);
                         if (ret != PQOS_RETVAL_OK)
                                 goto pqos_alloc_reset_exit;
 

--- a/lib/allocation.c
+++ b/lib/allocation.c
@@ -1318,6 +1318,8 @@ hw_alloc_reset(const enum pqos_cdp_config l3_cdp_cfg,
 {
 	unsigned *l3cat_ids = NULL;
 	unsigned l3cat_id_num = 0;
+	unsigned *mba_ids = NULL;
+	unsigned mba_id_num = 0;
         unsigned *l2ids = NULL;
         unsigned l2id_num = 0;
         const struct pqos_cap *cap;
@@ -1430,14 +1432,13 @@ hw_alloc_reset(const enum pqos_cdp_config l3_cdp_cfg,
                 goto pqos_alloc_reset_exit;
         }
 
-        /**
-	 * Get number & list of l3cat_ids in the system
-         */
-	l3cat_ids = pqos_cpu_get_l3cat_ids(m_cpu, &l3cat_id_num);
-	if (l3cat_ids == NULL || l3cat_id_num == 0)
-                goto pqos_alloc_reset_exit;
-
         if (l3_cap != NULL) {
+		/**
+		 * Get number & list of l3cat_ids in the system
+		 */
+		l3cat_ids = pqos_cpu_get_l3cat_ids(m_cpu, &l3cat_id_num);
+		if (l3cat_ids == NULL || l3cat_id_num == 0)
+			goto pqos_alloc_reset_exit;
                 /**
 		 * Change L3 COS definition on all l3cat ids
                  * so that each COS allows for access to all cache ways
@@ -1485,14 +1486,21 @@ hw_alloc_reset(const enum pqos_cdp_config l3_cdp_cfg,
         }
 
         if (mba_cap != NULL) {
+		/**
+		 * Get number & list of mba_ids in the system
+		 */
+		mba_ids = pqos_cpu_get_mba_ids(m_cpu, &mba_id_num);
+		if (mba_ids == NULL || mba_id_num == 0)
+			goto pqos_alloc_reset_exit;
+
                 /**
 		 * Go through all L3 CAT ids and reset MBA class definitions
                  * 0 is the default MBA COS value in linear mode.
                  */
-		for (j = 0; j < l3cat_id_num; j++) {
+		for (j = 0; j < mba_id_num; j++) {
                         unsigned core = 0;
 
-			ret = pqos_cpu_get_one_core(m_cpu, l3cat_ids[j], &core);
+			ret = pqos_cpu_get_one_core(m_cpu, mba_ids[j], &core);
                         if (ret != PQOS_RETVAL_OK)
                                 goto pqos_alloc_reset_exit;
 
@@ -1573,6 +1581,8 @@ hw_alloc_reset(const enum pqos_cdp_config l3_cdp_cfg,
  pqos_alloc_reset_exit:
 	if (l3cat_ids != NULL)
 		free(l3cat_ids);
+	if (mba_ids != NULL)
+		free(mba_ids);
         if (l2ids != NULL)
                 free(l2ids);
         return ret;

--- a/lib/allocation.c
+++ b/lib/allocation.c
@@ -52,6 +52,7 @@
 #include "machine.h"
 #include "types.h"
 #include "log.h"
+#include "cpu_registers.h"
 
 /**
  * ---------------------------------------
@@ -59,37 +60,6 @@
  * ---------------------------------------
  */
 
-/**
- * Allocation & Monitoring association MSR register
- * - bits [63..32] QE COS
- * - bits [31..10] Reserved
- * - bits [9..0] RMID
- */
-#define PQOS_MSR_ASSOC             0xC8F
-#define PQOS_MSR_ASSOC_QECOS_SHIFT 32
-#define PQOS_MSR_ASSOC_QECOS_MASK  0xffffffff00000000ULL
-
-/**
- * Allocation class of service (COS) MSR registers
- */
-#define PQOS_MSR_L3CA_MASK_START 0xC90
-#define PQOS_MSR_L3CA_MASK_END   0xD0F
-#define PQOS_MSR_L3CA_MASK_NUMOF                                \
-        (PQOS_MSR_L3CA_MASK_END - PQOS_MSR_L3CA_MASK_START + 1)
-
-#define PQOS_MSR_L2CA_MASK_START 0xD10
-#define PQOS_MSR_MBA_MASK_START  0xD50
-
-#define PQOS_MSR_L3_QOS_CFG          0xC81   /**< L3 CAT config register */
-#define PQOS_MSR_L3_QOS_CFG_CDP_EN   1ULL    /**< L3 CDP enable bit */
-
-#define PQOS_MSR_L2_QOS_CFG          0xC82   /**< L2 CAT config register */
-#define PQOS_MSR_L2_QOS_CFG_CDP_EN   1ULL    /**< L2 CDP enable bit */
-
-/**
- * MBA linear max value
- */
-#define PQOS_MBA_LINEAR_MAX 100
 
 /**
  * ---------------------------------------

--- a/lib/allocation.h
+++ b/lib/allocation.h
@@ -151,23 +151,23 @@ int hw_alloc_reset(const enum pqos_cdp_config l3_cdp_cfg,
 
 /**
  * @brief Hardware interface to set classes of service
- *        defined by \a ca on \a socket
+ *        defined by \a ca on \a l3cat_id
  *
- * @param [in] socket CPU socket id
+ * @param [in] l3cat_id L3 CAT resource id
  * @param [in] num_ca number of classes of service at \a ca
  * @param [in] ca table with class of service definitions
  *
  * @return Operations status
  * @retval PQOS_RETVAL_OK on success
  */
-int hw_l3ca_set(const unsigned socket,
+int hw_l3ca_set(const unsigned l3cat_id,
                 const unsigned num_ca,
                 const struct pqos_l3ca *ca);
 
 /**
- * @brief Hardware interface to read classes of service from \a socket
+ * @brief Hardware interface to read classes of service from \a l3cat id
  *
- * @param [in] socket CPU socket id
+ * @param [in] l3cat_id L3 CAT resource id
  * @param [in] max_num_ca maximum number of classes of service
  *             that can be accommodated at \a ca
  * @param [out] num_ca number of classes of service read into \a ca
@@ -176,7 +176,7 @@ int hw_l3ca_set(const unsigned socket,
  * @return Operations status
  * @retval PQOS_RETVAL_OK on success
  */
-int hw_l3ca_get(const unsigned socket,
+int hw_l3ca_get(const unsigned l3cat_id,
                 const unsigned max_num_ca,
                 unsigned *num_ca,
                 struct pqos_l3ca *ca);
@@ -243,9 +243,9 @@ int hw_l2ca_get_min_cbm_bits(unsigned *min_cbm_bits);
 
 /**
  * @brief Hardware interface to set classes of service
- *        defined by \a mba on \a socket
+ *        defined by \a MBA  on \a mba id
  *
- * @param [in]  socket CPU socket id
+ * @param [in]  mba_id MBA resource id
  * @param [in]  num_cos number of classes of service at \a ca
  * @param [in]  requested table with class of service definitions
  * @param [out] actual table with class of service definitions
@@ -253,15 +253,15 @@ int hw_l2ca_get_min_cbm_bits(unsigned *min_cbm_bits);
  * @return Operations status
  * @retval PQOS_RETVAL_OK on success
  */
-int hw_mba_set(const unsigned socket,
+int hw_mba_set(const unsigned mba_id,
                const unsigned num_cos,
                const struct pqos_mba *requested,
                struct pqos_mba *actual);
 
 /**
- * @brief Hardware interface to read MBA from \a socket
+ * @brief Hardware interface to read MBA from \a mba_id
  *
- * @param [in]  socket CPU socket id
+ * @param [in]  mba_id MBA resource id
  * @param [in]  max_num_cos maximum number of classes of service
  *              that can be accommodated at \a mba_tab
  * @param [out] num_cos number of classes of service read into \a mba_tab
@@ -270,7 +270,7 @@ int hw_mba_set(const unsigned socket,
  * @return Operations status
  * @retval PQOS_RETVAL_OK on success
  */
-int hw_mba_get(const unsigned socket,
+int hw_mba_get(const unsigned mba_id,
                const unsigned max_num_cos,
                unsigned *num_cos,
                struct pqos_mba *mba_tab);

--- a/lib/api.c
+++ b/lib/api.c
@@ -44,6 +44,7 @@
 #include "cap.h"
 #include "log.h"
 #include "types.h"
+#include "cpu_registers.h"
 
 /**
  * Value marking monitoring group structure as "valid".
@@ -755,9 +756,10 @@ pqos_mba_set(const unsigned socket,
 	 */
 	for (i = 0; i < num_cos; i++)
 		if (requested[i].ctrl == 0 &&
-		    (requested[i].mb_max == 0 || requested[i].mb_max > 100)) {
-			LOG_ERROR("MBA COS%u rate out of range (from 1-100)!\n",
-			          requested[i].class_id);
+		    (requested[i].mb_max == 0 ||
+		     requested[i].mb_max > PQOS_MBA_LINEAR_MAX)) {
+			LOG_ERROR("MBA COS%u rate out of range (from 1-%d)!\n",
+				   requested[i].class_id, PQOS_MBA_LINEAR_MAX);
 			return PQOS_RETVAL_PARAM;
 		}
 

--- a/lib/api.c
+++ b/lib/api.c
@@ -490,7 +490,7 @@ is_contiguous(uint64_t bitmask)
 }
 
 int
-pqos_l3ca_set(const unsigned socket,
+pqos_l3ca_set(const unsigned l3cat_id,
               const unsigned num_cos,
               const struct pqos_l3ca *ca)
 {
@@ -529,10 +529,10 @@ pqos_l3ca_set(const unsigned socket,
 	}
 
 	if (m_interface == PQOS_INTER_MSR)
-		ret = hw_l3ca_set(socket, num_cos, ca);
+		ret = hw_l3ca_set(l3cat_id, num_cos, ca);
 	else {
 #ifdef __linux__
-		ret = os_l3ca_set(socket, num_cos, ca);
+		ret = os_l3ca_set(l3cat_id, num_cos, ca);
 #else
                 LOG_INFO("OS interface not supported!\n");
                 ret = PQOS_RETVAL_RESOURCE;
@@ -544,7 +544,7 @@ pqos_l3ca_set(const unsigned socket,
 }
 
 int
-pqos_l3ca_get(const unsigned socket,
+pqos_l3ca_get(const unsigned l3cat_id,
               const unsigned max_num_ca,
               unsigned *num_ca,
               struct pqos_l3ca *ca)
@@ -562,10 +562,10 @@ pqos_l3ca_get(const unsigned socket,
                 return ret;
         }
 	if (m_interface == PQOS_INTER_MSR)
-		ret = hw_l3ca_get(socket, max_num_ca, num_ca, ca);
+		ret = hw_l3ca_get(l3cat_id, max_num_ca, num_ca, ca);
 	else {
 #ifdef __linux__
-		ret = os_l3ca_get(socket, max_num_ca, num_ca, ca);
+		ret = os_l3ca_get(l3cat_id, max_num_ca, num_ca, ca);
 #else
                 LOG_INFO("OS interface not supported!\n");
                 ret = PQOS_RETVAL_RESOURCE;
@@ -740,7 +740,7 @@ pqos_l2ca_get_min_cbm_bits(unsigned *min_cbm_bits)
  */
 
 int
-pqos_mba_set(const unsigned socket,
+pqos_mba_set(const unsigned mba_id,
              const unsigned num_cos,
              const struct pqos_mba *requested,
              struct pqos_mba *actual)
@@ -772,10 +772,10 @@ pqos_mba_set(const unsigned socket,
         }
 
         if (m_interface == PQOS_INTER_MSR)
-                ret = hw_mba_set(socket, num_cos, requested, actual);
+		ret = hw_mba_set(mba_id, num_cos, requested, actual);
         else {
 #ifdef __linux__
-                ret = os_mba_set(socket, num_cos, requested, actual);
+		ret = os_mba_set(mba_id, num_cos, requested, actual);
 #else
                 LOG_INFO("OS interface not supported!\n");
                 ret = PQOS_RETVAL_RESOURCE;
@@ -789,7 +789,7 @@ pqos_mba_set(const unsigned socket,
 }
 
 int
-pqos_mba_get(const unsigned socket,
+pqos_mba_get(const unsigned mba_id,
              const unsigned max_num_cos,
              unsigned *num_cos,
              struct pqos_mba *mba_tab)
@@ -808,10 +808,10 @@ pqos_mba_get(const unsigned socket,
         }
 
         if (m_interface == PQOS_INTER_MSR)
-                ret = hw_mba_get(socket, max_num_cos, num_cos, mba_tab);
+		ret = hw_mba_get(mba_id, max_num_cos, num_cos, mba_tab);
         else {
 #ifdef __linux__
-                ret = os_mba_get(socket, max_num_cos, num_cos, mba_tab);
+		ret = os_mba_get(mba_id, max_num_cos, num_cos, mba_tab);
 #else
                 LOG_INFO("OS interface not supported!\n");
                 ret = PQOS_RETVAL_RESOURCE;

--- a/lib/cap.c
+++ b/lib/cap.c
@@ -501,7 +501,7 @@ l3cdp_is_enabled(const struct pqos_cpuinfo *cpu,
                 uint64_t reg = 0;
                 unsigned core = 0;
 
-		ret = pqos_cpu_get_one_core(cpu, l3cat_ids[j], &core);
+		ret = pqos_cpu_get_one_by_l3cat_id(cpu, l3cat_ids[j], &core);
                 if (ret != PQOS_RETVAL_OK)
                         goto l3cdp_is_enabled_exit;
 

--- a/lib/cap.c
+++ b/lib/cap.c
@@ -479,8 +479,8 @@ static int
 l3cdp_is_enabled(const struct pqos_cpuinfo *cpu,
                int *enabled)
 {
-        unsigned *sockets = NULL;
-        unsigned sockets_num = 0, j = 0;
+	unsigned *l3cat_ids = NULL;
+	unsigned l3cat_id_num = 0, j = 0;
         unsigned enabled_num = 0, disabled_num = 0;
         int ret = PQOS_RETVAL_OK;
 
@@ -491,17 +491,17 @@ l3cdp_is_enabled(const struct pqos_cpuinfo *cpu,
         *enabled = 0;
 
         /**
-         * Get list of socket id's
+	 * Get list of l3cat id's
          */
-	sockets = pqos_cpu_get_sockets(cpu, &sockets_num);
-        if (sockets == NULL)
+	l3cat_ids = pqos_cpu_get_l3cat_ids(cpu, &l3cat_id_num);
+	if (l3cat_ids == NULL)
                 return PQOS_RETVAL_RESOURCE;
 
-        for (j = 0; j < sockets_num; j++) {
+	for (j = 0; j < l3cat_id_num; j++) {
                 uint64_t reg = 0;
                 unsigned core = 0;
 
-                ret = pqos_cpu_get_one_core(cpu, sockets[j], &core);
+		ret = pqos_cpu_get_one_core(cpu, l3cat_ids[j], &core);
                 if (ret != PQOS_RETVAL_OK)
                         goto l3cdp_is_enabled_exit;
 
@@ -518,7 +518,7 @@ l3cdp_is_enabled(const struct pqos_cpuinfo *cpu,
         }
 
         if (disabled_num > 0 && enabled_num > 0) {
-                LOG_ERROR("Inconsistent L3 CDP settings across sockets."
+		LOG_ERROR("Inconsistent L3 CDP settings across l3cat_ids."
                           "Please reset CAT or reboot your system!\n");
                 ret = PQOS_RETVAL_ERROR;
                 goto l3cdp_is_enabled_exit;
@@ -530,8 +530,8 @@ l3cdp_is_enabled(const struct pqos_cpuinfo *cpu,
         LOG_INFO("L3 CDP is %s\n", (*enabled) ? "enabled" : "disabled");
 
  l3cdp_is_enabled_exit:
-        if (sockets != NULL)
-                free(sockets);
+	if (l3cat_ids != NULL)
+		free(l3cat_ids);
 
         return ret;
 }

--- a/lib/cap.c
+++ b/lib/cap.c
@@ -66,6 +66,7 @@
 #include "allocation.h"
 #include "monitoring.h"
 
+#include "cpu_registers.h"
 #include "cpuinfo.h"
 #include "machine.h"
 #include "types.h"
@@ -81,31 +82,6 @@
  * ---------------------------------------
  */
 
-/**
- * Available types of allocation resource ID's.
- * (matches CPUID enumeration)
- */
-#define PQOS_RES_ID_L3_ALLOCATION    1       /**< L3 cache allocation */
-#define PQOS_RES_ID_L2_ALLOCATION    2       /**< L2 cache allocation */
-#define PQOS_RES_ID_MB_ALLOCATION    3       /**< Memory BW allocation */
-
-#define PQOS_CPUID_CAT_CDP_BIT       2       /**< CDP supported bit */
-
-#define PQOS_MSR_L3_QOS_CFG          0xC81   /**< L3 CAT config register */
-#define PQOS_MSR_L3_QOS_CFG_CDP_EN   1ULL    /**< L3 CDP enable bit */
-
-#define PQOS_MSR_L3CA_MASK_START     0xC90   /**< L3 CAT class 0 register */
-#define PQOS_MSR_L3CA_MASK_END       0xD0F   /**< L3 CAT class 127 register */
-#define PQOS_MSR_ASSOC               0xC8F   /**< CAT class to core association
-                                                register */
-#define PQOS_MSR_ASSOC_QECOS_SHIFT   32
-#define PQOS_MSR_ASSOC_QECOS_MASK    0xffffffff00000000ULL
-
-#define PQOS_MSR_L2_QOS_CFG          0xC82   /**< L2 CAT config register */
-#define PQOS_MSR_L2_QOS_CFG_CDP_EN   1ULL    /**< L2 CDP enable bit */
-
-#define PQOS_MSR_L2CA_MASK_START     0xC10   /**< L2 CAT class 0 register */
-#define PQOS_MSR_L2CA_MASK_END       0xD8F   /**< L2 CAT class 127 register */
 
 #ifndef LOCKFILE
 #ifdef __linux__

--- a/lib/cpu_registers.h
+++ b/lib/cpu_registers.h
@@ -1,0 +1,129 @@
+/*
+ * BSD LICENSE
+ *
+ * Copyright(c) 2014-2019 Intel Corporation. All rights reserved.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/**
+ * @brief Internal defines and data structure definition
+ */
+
+#ifndef __CPU_REGISTERS_H__
+#define __CPU_REGISTERS_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Allocation & Monitoring association MSR register
+ * - bits [63..32] QE COS
+ * - bits [31..10] Reserved
+ * - bits [9..0] RMID
+ */
+#define PQOS_MSR_ASSOC             0xC8F
+#define PQOS_MSR_ASSOC_QECOS_SHIFT 32
+#define PQOS_MSR_ASSOC_QECOS_MASK  0xffffffff00000000ULL
+#define PQOS_MSR_ASSOC_RMID_MASK   ((1ULL << 10) - 1ULL)
+
+/**
+ * Allocation class of service (COS) MSR registers
+ */
+#define PQOS_MSR_L3CA_MASK_START 0xC90
+#define PQOS_MSR_L3CA_MASK_END   0xD0F
+#define PQOS_MSR_L3CA_MASK_NUMOF				\
+	(PQOS_MSR_L3CA_MASK_END - PQOS_MSR_L3CA_MASK_START + 1)
+
+#define PQOS_MSR_L2CA_MASK_START 0xD10
+#define PQOS_MSR_MBA_MASK_START  0xD50
+
+#define PQOS_MSR_L3_QOS_CFG          0xC81   /**< L3 CAT config register */
+#define PQOS_MSR_L3_QOS_CFG_CDP_EN   1ULL    /**< L3 CDP enable bit */
+
+#define PQOS_MSR_L2_QOS_CFG          0xC82   /**< L2 CAT config register */
+#define PQOS_MSR_L2_QOS_CFG_CDP_EN   1ULL    /**< L2 CDP enable bit */
+
+/**
+ * MBA linear max value
+ */
+#define PQOS_MBA_LINEAR_MAX 100
+
+/**
+ * Available types of allocation resource ID's.
+ * (matches CPUID enumeration)
+ */
+#define PQOS_RES_ID_L3_ALLOCATION    1       /**< L3 cache allocation */
+#define PQOS_RES_ID_L2_ALLOCATION    2       /**< L2 cache allocation */
+#define PQOS_RES_ID_MB_ALLOCATION    3       /**< Memory BW allocation */
+
+#define PQOS_CPUID_CAT_CDP_BIT       2       /**< CDP supported bit */
+
+/**
+ * Monitoring data read MSR register
+ */
+#define PQOS_MSR_MON_QMC             0xC8E
+#define PQOS_MSR_MON_QMC_DATA_MASK   ((1ULL << 62) - 1ULL)
+#define PQOS_MSR_MON_QMC_ERROR       (1ULL << 63)
+#define PQOS_MSR_MON_QMC_UNAVAILABLE (1ULL << 62)
+
+/**
+ * Monitoring event selection MSR register
+ * - bits [63..42] Reserved
+ * - bits [41..32] RMID
+ * - bits [31..8] Reserved
+ * - bits [7..0] Event ID
+ */
+#define PQOS_MSR_MON_EVTSEL            0xC8D
+#define PQOS_MSR_MON_EVTSEL_RMID_SHIFT 32
+#define PQOS_MSR_MON_EVTSEL_RMID_MASK  ((1ULL << 10) - 1ULL)
+#define PQOS_MSR_MON_EVTSEL_EVTID_MASK ((1ULL << 8) - 1ULL)
+
+/**
+ * MSR's to read instructions retired, unhalted cycles,
+ * LLC references and LLC misses.
+ * These MSR's are needed to calculate IPC (instructions per clock) and
+ * LLC miss ratio.
+ */
+#define IA32_MSR_INST_RETIRED_ANY     0x309
+#define IA32_MSR_CPU_UNHALTED_THREAD  0x30A
+#define IA32_MSR_FIXED_CTR_CTRL       0x38D
+#define IA32_MSR_PERF_GLOBAL_CTRL     0x38F
+#define IA32_MSR_PMC0                 0x0C1
+#define IA32_MSR_PERFEVTSEL0          0x186
+
+#define IA32_EVENT_LLC_MISS_MASK      0x2EULL
+#define IA32_EVENT_LLC_MISS_UMASK     0x41ULL
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CPU_REGISTERS_H__ */

--- a/lib/cpuinfo.c
+++ b/lib/cpuinfo.c
@@ -386,6 +386,16 @@ detect_cpu(const int cpu,
         info->l3_id = apicid >> apic->l3_shift;
         info->l2_id = apicid >> apic->l2_shift;
 
+	/*
+	 * Update l3cat_id and mba_id. For Intel, CAT and MBA ids are
+	 * initialized to socket id. AMD uses l3_id for both CAT and MBA
+	 * ids. Right now, both these ids are same. This could change in
+	 * the future.
+	 */
+
+	info->l3cat_id = info->socket;
+	info->mba_id = info->socket;
+
         LOG_DEBUG("Detected core %u, socket %u, "
                   "L2 ID %u, L3 ID %u, APICID %u\n",
                   info->lcore, info->socket,

--- a/lib/monitoring.c
+++ b/lib/monitoring.c
@@ -51,67 +51,13 @@
 #include "machine.h"
 #include "types.h"
 #include "log.h"
+#include "cpu_registers.h"
 
 /**
  * ---------------------------------------
  * Local macros
  * ---------------------------------------
  */
-
-/**
- * Allocation & Monitoring association MSR register
- * - bits [63..32] QE COS
- * - bits [31..10] Reserved
- * - bits [9..0]   RMID
- */
-#define PQOS_MSR_ASSOC             0xC8F
-#define PQOS_MSR_ASSOC_QECOS_SHIFT 32
-#define PQOS_MSR_ASSOC_QECOS_MASK  0xffffffff00000000ULL
-#define PQOS_MSR_ASSOC_RMID_MASK   ((1ULL << 10) - 1ULL)
-
-/**
- * Monitoring data read MSR register
- */
-#define PQOS_MSR_MON_QMC             0xC8E
-#define PQOS_MSR_MON_QMC_DATA_MASK   ((1ULL << 62) - 1ULL)
-#define PQOS_MSR_MON_QMC_ERROR       (1ULL << 63)
-#define PQOS_MSR_MON_QMC_UNAVAILABLE (1ULL << 62)
-
-/**
- * Monitoring event selection MSR register
- * - bits [63..42] Reserved
- * - bits [41..32] RMID
- * - bits [31..8] Reserved
- * - bits [7..0] Event ID
- */
-#define PQOS_MSR_MON_EVTSEL            0xC8D
-#define PQOS_MSR_MON_EVTSEL_RMID_SHIFT 32
-#define PQOS_MSR_MON_EVTSEL_RMID_MASK  ((1ULL << 10) - 1ULL)
-#define PQOS_MSR_MON_EVTSEL_EVTID_MASK ((1ULL << 8) - 1ULL)
-
-/**
- * Allocation class of service (COS) MSR registers
- */
-#define PQOS_MSR_L3CA_MASK_START 0xC90
-#define PQOS_MSR_L3CA_MASK_END   0xD8F
-#define PQOS_MSR_L3CA_MASK_NUMOF \
-        (PQOS_MSR_L3CA_MASK_END - PQOS_MSR_L3CA_MASK_START + 1)
-
-/**
- * MSR's to read instructions retired, unhalted cycles,
- * LLC references and LLC misses.
- * These MSR's are needed to calculate IPC (instructions per clock) and
- * LLC miss ratio.
- */
-#define IA32_MSR_INST_RETIRED_ANY     0x309
-#define IA32_MSR_CPU_UNHALTED_THREAD  0x30A
-#define IA32_MSR_FIXED_CTR_CTRL       0x38D
-#define IA32_MSR_PERF_GLOBAL_CTRL     0x38F
-#define IA32_MSR_PMC0                 0x0C1
-#define IA32_MSR_PERFEVTSEL0          0x186
-
-#define IA32_EVENT_LLC_MISS_MASK      0x2EULL
-#define IA32_EVENT_LLC_MISS_UMASK     0x41ULL
 
 /**
  * Special RMID - after reset all cores are associated with it.

--- a/lib/os_allocation.c
+++ b/lib/os_allocation.c
@@ -1022,6 +1022,39 @@ verify_l3cat_id(const unsigned l3cat_id, const struct pqos_cpuinfo *cpu)
 	return ret;
 }
 
+/*
+ * @brief Check if mba_id is correct
+ *
+ * @param [in] mba_id MBA resource id
+ * @param [in] CPU information structure from \a pqos_cap_get
+ *
+ * @return Operations status
+ * @retval PQOS_RETVAL_OK on success
+ */
+static int
+verify_mba_id(const unsigned mba_id, const struct pqos_cpuinfo *cpu)
+{
+	int ret = PQOS_RETVAL_PARAM;
+	unsigned i;
+	unsigned mba_id_num;
+	unsigned *mba_ids;
+
+	/* Get mba ids in the system */
+	mba_ids = pqos_cpu_get_mba_ids(cpu, &mba_id_num);
+	if (mba_ids == NULL)
+		return PQOS_RETVAL_ERROR;
+
+	for (i = 0; i < mba_id_num; ++i)
+		if (mba_id == mba_ids[i]) {
+			ret = PQOS_RETVAL_OK;
+			break;
+		}
+
+	free(mba_ids);
+
+	return ret;
+}
+
 int
 os_l3ca_set(const unsigned socket,
             const unsigned num_cos,
@@ -1490,7 +1523,7 @@ os_mba_set(const unsigned socket,
 			return PQOS_RETVAL_PARAM;
 		}
 
-	ret = verify_l3cat_id(socket, cpu);
+	ret = verify_mba_id(socket, cpu);
         if (ret != PQOS_RETVAL_OK)
                 goto os_mba_set_exit;
 
@@ -1604,7 +1637,7 @@ os_mba_get(const unsigned socket,
 	if (count > max_num_cos)
 		return PQOS_RETVAL_ERROR;
 
-	ret = verify_l3cat_id(socket, cpu);
+	ret = verify_mba_id(socket, cpu);
         if (ret != PQOS_RETVAL_OK)
                 goto os_mba_get_exit;
 

--- a/lib/os_allocation.c
+++ b/lib/os_allocation.c
@@ -1490,7 +1490,7 @@ os_l2ca_get_min_cbm_bits(unsigned *min_cbm_bits)
 }
 
 int
-os_mba_set(const unsigned socket,
+os_mba_set(const unsigned mba_id,
            const unsigned num_cos,
            const struct pqos_mba *requested,
            struct pqos_mba *actual)
@@ -1533,7 +1533,7 @@ os_mba_set(const unsigned socket,
 			return PQOS_RETVAL_PARAM;
 		}
 
-	ret = verify_mba_id(socket, cpu);
+	ret = verify_mba_id(mba_id, cpu);
         if (ret != PQOS_RETVAL_OK)
                 goto os_mba_set_exit;
 
@@ -1580,7 +1580,7 @@ os_mba_set(const unsigned socket,
                                         mba.mb_max = step;
 			}
 
-                        ret = resctrl_schemata_mba_set(schmt, socket, &mba);
+			ret = resctrl_schemata_mba_set(schmt, mba_id, &mba);
                 }
 
                 /* write schemata */
@@ -1596,7 +1596,7 @@ os_mba_set(const unsigned socket,
 
 			/* update actual schemata */
                         if (ret == PQOS_RETVAL_OK) {
-                                ret = resctrl_schemata_mba_get(schmt, socket,
+				ret = resctrl_schemata_mba_get(schmt, mba_id,
                                                                &actual[i]);
                                 actual[i].class_id = requested[i].class_id;
                         }
@@ -1615,7 +1615,7 @@ os_mba_set(const unsigned socket,
 }
 
 int
-os_mba_get(const unsigned socket,
+os_mba_get(const unsigned mba_id,
            const unsigned max_num_cos,
            unsigned *num_cos,
            struct pqos_mba *mba_tab)
@@ -1647,7 +1647,7 @@ os_mba_get(const unsigned socket,
 	if (count > max_num_cos)
 		return PQOS_RETVAL_ERROR;
 
-	ret = verify_mba_id(socket, cpu);
+	ret = verify_mba_id(mba_id, cpu);
         if (ret != PQOS_RETVAL_OK)
                 goto os_mba_get_exit;
 
@@ -1666,8 +1666,8 @@ os_mba_get(const unsigned socket,
 			ret = resctrl_alloc_schemata_read(class_id, schmt);
 
 		if (ret == PQOS_RETVAL_OK)
-                        ret = resctrl_schemata_mba_get(schmt, socket,
-                                                       &mba_tab[class_id]);
+			ret = resctrl_schemata_mba_get(schmt, mba_id,
+						       &mba_tab[class_id]);
 
                 mba_tab[class_id].class_id = class_id;
 

--- a/lib/os_allocation.c
+++ b/lib/os_allocation.c
@@ -990,36 +990,36 @@ os_alloc_reset(const enum pqos_cdp_config l3_cdp_cfg,
 }
 
 /*
- * @brief Check if socket is correct
+ * @brief Check if l3cat_id is correct
  *
- * @param [in] socket CPU socket id
+ * @param [in] cpu l3cat id
  * @param [in] cpu CPU information structure from \a pqos_cap_get
  *
  * @return Operations status
  * @retval PQOS_RETVAL_OK on success
  */
 static int
-verify_socket_id(const unsigned socket, const struct pqos_cpuinfo *cpu)
+verify_l3cat_id(const unsigned l3cat_id, const struct pqos_cpuinfo *cpu)
 {
-        int ret = PQOS_RETVAL_PARAM;
-        unsigned i;
-        unsigned sockets_num;
-        unsigned *sockets;
+	int ret = PQOS_RETVAL_PARAM;
+	unsigned i;
+	unsigned l3cat_num;
+	unsigned *l3cat_ids;
 
-        /* Get socket ids in the system */
-        sockets = pqos_cpu_get_sockets(cpu, &sockets_num);
-        if (sockets == NULL)
-                return PQOS_RETVAL_ERROR;
+	/* Get l3cat ids in the system */
+	l3cat_ids = pqos_cpu_get_l3cat_ids(cpu, &l3cat_num);
+	if (l3cat_ids == NULL)
+		return PQOS_RETVAL_ERROR;
 
-        for (i = 0; i < sockets_num; ++i)
-                if (socket == sockets[i]) {
-                        ret = PQOS_RETVAL_OK;
-                        break;
-                }
+	for (i = 0; i < l3cat_num; ++i)
+		if (l3cat_id == l3cat_ids[i]) {
+			ret = PQOS_RETVAL_OK;
+			break;
+		}
 
-        free(sockets);
+	free(l3cat_ids);
 
-        return ret;
+	return ret;
 }
 
 int
@@ -1050,7 +1050,7 @@ os_l3ca_set(const unsigned socket,
 	if (num_cos > num_grps)
 		return PQOS_RETVAL_ERROR;
 
-        ret = verify_socket_id(socket, cpu);
+	ret = verify_l3cat_id(socket, cpu);
         if (ret != PQOS_RETVAL_OK)
                 goto os_l3ca_set_exit;
 
@@ -1142,7 +1142,7 @@ os_l3ca_get(const unsigned socket,
 	if (count > max_num_ca)
 		return PQOS_RETVAL_ERROR;
 
-        ret = verify_socket_id(socket, cpu);
+	ret = verify_l3cat_id(socket, cpu);
         if (ret != PQOS_RETVAL_OK)
                 goto os_l3ca_get_exit;
 
@@ -1490,7 +1490,7 @@ os_mba_set(const unsigned socket,
 			return PQOS_RETVAL_PARAM;
 		}
 
-        ret = verify_socket_id(socket, cpu);
+	ret = verify_l3cat_id(socket, cpu);
         if (ret != PQOS_RETVAL_OK)
                 goto os_mba_set_exit;
 
@@ -1604,7 +1604,7 @@ os_mba_get(const unsigned socket,
 	if (count > max_num_cos)
 		return PQOS_RETVAL_ERROR;
 
-        ret = verify_socket_id(socket, cpu);
+	ret = verify_l3cat_id(socket, cpu);
         if (ret != PQOS_RETVAL_OK)
                 goto os_mba_get_exit;
 

--- a/lib/os_allocation.c
+++ b/lib/os_allocation.c
@@ -1055,8 +1055,18 @@ verify_mba_id(const unsigned mba_id, const struct pqos_cpuinfo *cpu)
 	return ret;
 }
 
+/*
+ * @brief Set the bitmask for a given COS
+ *
+ * @param [in] l3cat_id L3 cat identifier
+ * @param [in] num_cos Total number of COS
+ * @param [in] ca Bitmask information to set
+ *
+ * @return Operations status
+ * @retval PQOS_RETVAL_OK on success
+ */
 int
-os_l3ca_set(const unsigned socket,
+os_l3ca_set(const unsigned l3cat_id,
             const unsigned num_cos,
             const struct pqos_l3ca *ca)
 {
@@ -1083,7 +1093,7 @@ os_l3ca_set(const unsigned socket,
 	if (num_cos > num_grps)
 		return PQOS_RETVAL_ERROR;
 
-	ret = verify_l3cat_id(socket, cpu);
+	ret = verify_l3cat_id(l3cat_id, cpu);
         if (ret != PQOS_RETVAL_OK)
                 goto os_l3ca_set_exit;
 
@@ -1125,7 +1135,7 @@ os_l3ca_set(const unsigned socket,
 			} else
 				l3ca = ca[i];
 
-                        ret = resctrl_schemata_l3ca_set(schmt, socket, &l3ca);
+			ret = resctrl_schemata_l3ca_set(schmt, l3cat_id, &l3ca);
                 }
 
 		/* write schemata */
@@ -1147,7 +1157,7 @@ os_l3ca_set(const unsigned socket,
 }
 
 int
-os_l3ca_get(const unsigned socket,
+os_l3ca_get(const unsigned l3cat_id,
             const unsigned max_num_ca,
             unsigned *num_ca,
             struct pqos_l3ca *ca)
@@ -1175,7 +1185,7 @@ os_l3ca_get(const unsigned socket,
 	if (count > max_num_ca)
 		return PQOS_RETVAL_ERROR;
 
-	ret = verify_l3cat_id(socket, cpu);
+	ret = verify_l3cat_id(l3cat_id, cpu);
         if (ret != PQOS_RETVAL_OK)
                 goto os_l3ca_get_exit;
 
@@ -1194,7 +1204,7 @@ os_l3ca_get(const unsigned socket,
                         ret = resctrl_alloc_schemata_read(class_id, schmt);
 
                 if (ret == PQOS_RETVAL_OK)
-                        ret = resctrl_schemata_l3ca_get(schmt, socket,
+			ret = resctrl_schemata_l3ca_get(schmt, l3cat_id,
                                                         &ca[class_id]);
 
                 ca[class_id].class_id = class_id;

--- a/lib/os_allocation.c
+++ b/lib/os_allocation.c
@@ -58,17 +58,7 @@
  */
 static const struct pqos_cpuinfo *m_cpu = NULL;
 
-/**
- * @brief Function to mount the resctrl file system with CDP option
- *
- * @param l3_cdp_cfg L3 CDP option
- * @param l2_cdp_cfg L2 CDP option
- * @param mba_cfg requested MBA config
- *
- * @return Operational status
- * @retval PQOS_RETVAL_OK on success
- */
-static int
+int
 os_interface_mount(const enum pqos_cdp_config l3_cdp_cfg,
                    const enum pqos_cdp_config l2_cdp_cfg,
                    const enum pqos_mba_config mba_cfg)
@@ -141,13 +131,7 @@ os_interface_mount(const enum pqos_cdp_config l3_cdp_cfg,
         return resctrl_mount(l3_cdp_cfg, l2_cdp_cfg, mba_cfg);
 }
 
-/**
- * @brief Check to see if resctrl is supported.
- *        If it is attempt to mount the file system.
- *
- * @return Operational status
- */
-static int
+int
 os_alloc_check(void)
 {
         int ret;
@@ -195,14 +179,7 @@ os_alloc_check(void)
         return PQOS_RETVAL_OK;
 }
 
-/**
- * @brief Prepares and authenticates resctrl file system
- *        used for OS allocation interface
- *
- * @return Operational status
- * @retval PQOS_RETVAL_OK success
- */
-static int
+int
 os_alloc_prep(void)
 {
         unsigned i, num_grps = 0;
@@ -461,12 +438,7 @@ os_alloc_release(const unsigned *core_array, const unsigned core_num)
         return ret;
 }
 
-/**
- * @brief Moves all cores to COS0 (default)
- *
- * @return Operation status
- */
-static int
+int
 os_alloc_reset_cores(void)
 {
 	const unsigned default_cos = 0;
@@ -490,16 +462,7 @@ os_alloc_reset_cores(void)
 	return ret;
 }
 
-/**
- * @brief Resets L3, L2 and MBA schematas to default value
- *
- * @param [in] l3_cap l3 cache capability
- * @param [in] l2_cap l2 cache capability
- * @param [in] mba_cap mba capability
- *
- * @return Operation status
- */
-static int
+int
 os_alloc_reset_schematas(const struct pqos_cap_l3ca *l3_cap,
                          const struct pqos_cap_l2ca *l2_cap,
                          const struct pqos_cap_mba *mba_cap)
@@ -585,12 +548,7 @@ filter_pids(const struct dirent *dir)
         return 1;
 }
 
-/**
- * @brief Move all tasks to COS0 (default)
- *
- * @return Operation status
- */
-static int
+int
 os_alloc_reset_tasks(void)
 {
 	struct dirent **pids_list = NULL;
@@ -626,22 +584,7 @@ os_alloc_reset_tasks(void)
 	return alloc_result;
 }
 
-/**
- * @brief Performs "light reset" of CAT.
- *
- * Moves all cores to default COS
- * Resets all l3 schematas to default value
- * Resets all l2 schematas to default value
- * Resets all mba schematas to default value
- * Moves all tasks to default COS
- *
- * @param [in] l3_cap L3 CAT capability
- * @param [in] l2_cap L2 CAT capability
- * @param [in] mba_cap MBA capability
- *
- * @return Operation status
- */
-static int
+int
 os_alloc_reset_light(const struct pqos_cap_l3ca *l3_cap,
 		     const struct pqos_cap_l2ca *l2_cap,
                      const struct pqos_cap_mba *mba_cap)
@@ -666,17 +609,7 @@ os_alloc_reset_light(const struct pqos_cap_l3ca *l3_cap,
 	return ret;
 }
 
-/**
- * @brief updates CDP for l2 cache capability
- *
- * @param [in] l2_cdp_cfg requsted l2 cdp configuration
- * @param [in] l2_cap l2 capability
- * @param [out] l2_cdp id of default COS
- *
- * @retval > 0 on l2_cdp change
- * @retval 0 on no change
- */
-static int
+int
 l2_cdp_update(const enum pqos_cdp_config l2_cdp_cfg,
 	      const struct pqos_cap_l2ca *l2_cap,
 	      enum pqos_cdp_config *l2_cdp)
@@ -705,17 +638,7 @@ l2_cdp_update(const enum pqos_cdp_config l2_cdp_cfg,
 	return ret;
 }
 
-/**
- * @brief updates CDP for l3 cache capability
- *
- * @param [in] l3_cdp_cfg requsted l3 cdp configuration
- * @param [in] l3_cap l3 capability
- * @param [out] l3_cdp id of default COS
- *
- * @retval > 0 on l3_cdp change
- * @retval 0 on no change
- */
-static int
+int
 l3_cdp_update(const enum pqos_cdp_config l3_cdp_cfg,
               const struct pqos_cap_l3ca *l3_cap,
               enum pqos_cdp_config *l3_cdp)
@@ -744,17 +667,7 @@ l3_cdp_update(const enum pqos_cdp_config l3_cdp_cfg,
         return ret;
 }
 
-/**
- * @brief updates MBA configuration for MBA capability
- *
- * @param [in] mba_cfg requsted MBA configuration
- * @param [in] mba_cap MBA capability
- * @param [out] mba_ctrl updated MBA config
- *
- * @retval > 0 mba_ctrl change
- * @retval 0 no change
- */
-static int
+int
 mba_cfg_update(const enum pqos_mba_config mba_cfg,
                 const struct pqos_cap_mba *mba_cap,
                 enum pqos_mba_config *mba_ctrl)
@@ -784,22 +697,7 @@ mba_cfg_update(const enum pqos_mba_config mba_cfg,
         return ret;
 }
 
-/**
- * @brief Performs "full reset" of CAT.
- *
- * Allocs all cores to default COS
- * Remounts resctrl file system with new CDP configuration
- *
- * @param [in] l3_cdp_cfg requested L3 CAT CDP config
- * @param [in] l2_cdp_cfg requested L2 CAT CDP config
- * @param [in] mba_cfg requested MBA config
- * @param [in] l3_cap l3 capability
- * @param [in] l2_cap l2 capability
- * @param [in] mba_cap mba capability
- *
- * @return Operation status
- */
-static int
+int
 os_alloc_reset_full(const enum pqos_cdp_config l3_cdp_cfg,
 		    const enum pqos_cdp_config l2_cdp_cfg,
                     const enum pqos_mba_config mba_cfg,
@@ -989,16 +887,7 @@ os_alloc_reset(const enum pqos_cdp_config l3_cdp_cfg,
         return ret;
 }
 
-/*
- * @brief Check if l3cat_id is correct
- *
- * @param [in] cpu l3cat id
- * @param [in] cpu CPU information structure from \a pqos_cap_get
- *
- * @return Operations status
- * @retval PQOS_RETVAL_OK on success
- */
-static int
+int
 verify_l3cat_id(const unsigned l3cat_id, const struct pqos_cpuinfo *cpu)
 {
 	int ret = PQOS_RETVAL_PARAM;
@@ -1022,16 +911,7 @@ verify_l3cat_id(const unsigned l3cat_id, const struct pqos_cpuinfo *cpu)
 	return ret;
 }
 
-/*
- * @brief Check if mba_id is correct
- *
- * @param [in] mba_id MBA resource id
- * @param [in] CPU information structure from \a pqos_cap_get
- *
- * @return Operations status
- * @retval PQOS_RETVAL_OK on success
- */
-static int
+int
 verify_mba_id(const unsigned mba_id, const struct pqos_cpuinfo *cpu)
 {
 	int ret = PQOS_RETVAL_PARAM;
@@ -1055,16 +935,6 @@ verify_mba_id(const unsigned mba_id, const struct pqos_cpuinfo *cpu)
 	return ret;
 }
 
-/*
- * @brief Set the bitmask for a given COS
- *
- * @param [in] l3cat_id L3 cat identifier
- * @param [in] num_cos Total number of COS
- * @param [in] ca Bitmask information to set
- *
- * @return Operations status
- * @retval PQOS_RETVAL_OK on success
- */
 int
 os_l3ca_set(const unsigned l3cat_id,
             const unsigned num_cos,
@@ -1255,16 +1125,7 @@ os_l3ca_get_min_cbm_bits(unsigned *min_cbm_bits)
 	return ret;
 }
 
-/*
- * @brief Check if L2 id is correct
- *
- * @param [in] l2id unique L2 cache identifier
- * @param [in] cpu CPU information structure from \a pqos_cap_get
- *
- * @return Operations status
- * @retval PQOS_RETVAL_OK on success
- */
-static int
+int
 verify_l2_id(const unsigned l2id, const struct pqos_cpuinfo *cpu)
 {
         int ret = PQOS_RETVAL_PARAM;

--- a/lib/os_allocation.h
+++ b/lib/os_allocation.h
@@ -339,6 +339,179 @@ int os_alloc_assoc_set_pid(const pid_t task,
 int os_alloc_assoc_get_pid(const pid_t task,
                            unsigned *class_id);
 
+/*
+ * @brief Check if L2 id is correct
+ *
+ * @param [in] l2id unique L2 cache identifier
+ * @param [in] cpu CPU information structure from \a pqos_cap_get
+ *
+ * @return Operations status
+ * @retval PQOS_RETVAL_OK on success
+ */
+int verify_l2_id(const unsigned l2id, const struct pqos_cpuinfo *cpu);
+
+/*
+ * @brief Check if l3cat_id is correct
+ *
+ * @param [in] cpu l3cat id
+ * @param [in] cpu CPU information structure from \a pqos_cap_get
+ *
+ * @return Operations status
+ * @retval PQOS_RETVAL_OK on success
+ */
+int verify_l3cat_id(const unsigned l3cat_id, const struct pqos_cpuinfo *cpu);
+
+/*
+ * @brief Check if mba_id is correct
+ *
+ * @param [in] mba_id MBA resource id
+ * @param [in] CPU information structure from \a pqos_cap_get
+ *
+ * @return Operations status
+ * @retval PQOS_RETVAL_OK on success
+ */
+int verify_mba_id(const unsigned mba_id, const struct pqos_cpuinfo *cpu);
+
+/**
+ * @brief Move all tasks to COS0 (default)
+ *
+ * @return Operation status
+ */
+int os_alloc_reset_tasks(void);
+
+/**
+ * @brief Performs "light reset" of CAT.
+ *
+ * Moves all cores to default COS
+ * Resets all l3 schematas to default value
+ * Resets all l2 schematas to default value
+ * Resets all mba schematas to default value
+ * Moves all tasks to default COS
+ *
+ * @param [in] l3_cap L3 CAT capability
+ * @param [in] l2_cap L2 CAT capability
+ * @param [in] mba_cap MBA capability
+ *
+ * @return Operation status
+ */
+int os_alloc_reset_light(const struct pqos_cap_l3ca *l3_cap,
+			 const struct pqos_cap_l2ca *l2_cap,
+			 const struct pqos_cap_mba *mba_cap);
+
+/**
+ * @brief updates CDP for l2 cache capability
+ *
+ * @param [in] l2_cdp_cfg requsted l2 cdp configuration
+ * @param [in] l2_cap l2 capability
+ * @param [out] l2_cdp id of default COS
+ *
+ * @retval > 0 on l2_cdp change
+ * @retval 0 on no change
+ */
+int l2_cdp_update(const enum pqos_cdp_config l2_cdp_cfg,
+		  const struct pqos_cap_l2ca *l2_cap,
+		  enum pqos_cdp_config *l2_cdp);
+
+/**
+ * @brief updates CDP for l3 cache capability
+ *
+ * @param [in] l3_cdp_cfg requsted l3 cdp configuration
+ * @param [in] l3_cap l3 capability
+ * @param [out] l3_cdp id of default COS
+ *
+ * @retval > 0 on l3_cdp change
+ * @retval 0 on no change
+ */
+int l3_cdp_update(const enum pqos_cdp_config l3_cdp_cfg,
+		  const struct pqos_cap_l3ca *l3_cap,
+		  enum pqos_cdp_config *l3_cdp);
+
+/**
+ * @brief updates MBA configuration for MBA capability
+ *
+ * @param [in] mba_cfg requsted MBA configuration
+ * @param [in] mba_cap MBA capability
+ * @param [out] mba_ctrl updated MBA config
+ *
+ * @retval > 0 mba_ctrl change
+ * @retval 0 no change
+ */
+int mba_cfg_update(const enum pqos_mba_config mba_cfg,
+		   const struct pqos_cap_mba *mba_cap,
+		   enum pqos_mba_config *mba_ctrl);
+
+/**
+ * @brief Performs "full reset" of CAT.
+ *
+ * Allocs all cores to default COS
+ * Remounts resctrl file system with new CDP configuration
+ *
+ * @param [in] l3_cdp_cfg requested L3 CAT CDP config
+ * @param [in] l2_cdp_cfg requested L2 CAT CDP config
+ * @param [in] mba_cfg requested MBA config
+ * @param [in] l3_cap l3 capability
+ * @param [in] l2_cap l2 capability
+ * @param [in] mba_cap mba capability
+ *
+ * @return Operation status
+ */
+int os_alloc_reset_full(const enum pqos_cdp_config l3_cdp_cfg,
+			const enum pqos_cdp_config l2_cdp_cfg,
+			const enum pqos_mba_config mba_cfg,
+			const struct pqos_cap_l3ca *l3_cap,
+			const struct pqos_cap_l2ca *l2_cap,
+			const struct pqos_cap_mba *mba_cap);
+/**
+ * @brief Function to mount the resctrl file system with CDP option
+ *
+ * @param l3_cdp_cfg L3 CDP option
+ * @param l2_cdp_cfg L2 CDP option
+ * @param mba_cfg requested MBA config
+ *
+ * @return Operational status
+ * @retval PQOS_RETVAL_OK on success
+ */
+int os_interface_mount(const enum pqos_cdp_config l3_cdp_cfg,
+		       const enum pqos_cdp_config l2_cdp_cfg,
+		       const enum pqos_mba_config mba_cfg);
+
+/**
+ * @brief Check to see if resctrl is supported.
+ *        If it is attempt to mount the file system.
+ *
+ * @return Operational status
+ */
+int os_alloc_check(void);
+
+/**
+ * @brief Prepares and authenticates resctrl file system
+ *        used for OS allocation interface
+ *
+ * @return Operational status
+ * @retval PQOS_RETVAL_OK success
+ */
+int os_alloc_prep(void);
+
+/**
+ * @brief Moves all cores to COS0 (default)
+ *
+ * @return Operation status
+ */
+int os_alloc_reset_cores(void);
+
+/**
+ * @brief Resets L3, L2 and MBA schematas to default value
+ *
+ * @param [in] l3_cap l3 cache capability
+ * @param [in] l2_cap l2 cache capability
+ * @param [in] mba_cap mba capability
+ *
+ * @return Operation status
+ */
+int os_alloc_reset_schematas(const struct pqos_cap_l3ca *l3_cap,
+			     const struct pqos_cap_l2ca *l2_cap,
+			     const struct pqos_cap_mba *mba_cap);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/os_allocation.h
+++ b/lib/os_allocation.h
@@ -160,23 +160,23 @@ int os_alloc_reset(const enum pqos_cdp_config l3_cdp_cfg,
 
 /**
  * @brief OS interface to set classes of service
- *        defined by \a ca on \a socket
+ *        defined by \a ca on \a l3cat_id
  *
- * @param [in] socket CPU socket id
+ * @param [in] l3cat_id L3 CAT resource id
  * @param [in] num_cos number of classes of service at \a ca
  * @param [in] ca table with class of service definitions
  *
  * @return Operations status
  * @retval PQOS_RETVAL_OK on success
  */
-int os_l3ca_set(const unsigned socket,
+int os_l3ca_set(const unsigned l3cat_id,
                 const unsigned num_cos,
                 const struct pqos_l3ca *ca);
 
 /**
- * @brief OS interface to read classes of service from \a socket
+ * @brief OS interface to read classes of service from \a l3cat_id
  *
- * @param [in] socket CPU socket id
+ * @param [in] l3cat_id L3 CAT resource id
  * @param [in] max_num_ca maximum number of classes of service
  *             that can be accommodated at \a ca
  * @param [out] num_ca number of classes of service read into \a ca
@@ -185,7 +185,7 @@ int os_l3ca_set(const unsigned socket,
  * @return Operations status
  * @retval PQOS_RETVAL_OK on success
  */
-int os_l3ca_get(const unsigned socket,
+int os_l3ca_get(const unsigned l3cat_id,
                 const unsigned max_num_ca,
                 unsigned *num_ca,
                 struct pqos_l3ca *ca);
@@ -244,9 +244,9 @@ int os_l2ca_get_min_cbm_bits(unsigned *min_cbm_bits);
 
 /**
  * @brief OS interface to set classes of service
- *        defined by \a mba on \a socket
+ *        defined by \a MBA id
  *
- * @param [in]  socket CPU socket id
+ * @param [in]  mba_id MBA resource id
  * @param [in]  num_cos number of classes of service at \a ca
  * @param [in]  requested table with class of service definitions
  * @param [out] actual table with class of service definitions
@@ -254,15 +254,15 @@ int os_l2ca_get_min_cbm_bits(unsigned *min_cbm_bits);
  * @return Operations status
  * @retval PQOS_RETVAL_OK on success
  */
-int os_mba_set(const unsigned socket,
+int os_mba_set(const unsigned mba_id,
                const unsigned num_cos,
                const struct pqos_mba *requested,
                struct pqos_mba *actual);
 
 /**
- * @brief OS interface to read MBA from \a socket
+ * @brief OS interface to read MBA from \a mba_id
  *
- * @param [in]  socket CPU socket id
+ * @param [in]  mba_id MBA resource id
  * @param [in]  max_num_cos maximum number of classes of service
  *              that can be accommodated at \a mba_tab
  * @param [out] num_cos number of classes of service read into \a mba_tab
@@ -271,7 +271,7 @@ int os_mba_set(const unsigned socket,
  * @return Operations status
  * @retval PQOS_RETVAL_OK on success
  */
-int os_mba_get(const unsigned socket,
+int os_mba_get(const unsigned mba_id,
                const unsigned max_num_cos,
                unsigned *num_cos,
                struct pqos_mba *mba_tab);

--- a/lib/os_cap.c
+++ b/lib/os_cap.c
@@ -762,20 +762,20 @@ os_cap_get_mba_ctrl(const struct pqos_cap *cap,
                 unsigned grp;
                 unsigned count = 0;
                 unsigned i;
-                unsigned *sock, sock_num;
+		unsigned *mba_ids, mba_id_num;
                 struct resctrl_schemata *schmt;
 
                 ret = resctrl_alloc_get_grps_num(cap, &count);
                 if (ret != PQOS_RETVAL_OK)
                         return ret;
 
-                sock = pqos_cpu_get_sockets(cpu, &sock_num);
-                if (sock == NULL)
+		mba_ids = pqos_cpu_get_mba_ids(cpu, &mba_id_num);
+		if (mba_ids == NULL)
                         return PQOS_RETVAL_ERROR;
 
                 schmt = resctrl_schemata_alloc(cap, cpu);
                 if (schmt == NULL) {
-                        free(sock);
+			free(mba_ids);
                         return PQOS_RETVAL_ERROR;
                 }
 
@@ -784,11 +784,12 @@ os_cap_get_mba_ctrl(const struct pqos_cap *cap,
                         if (ret != PQOS_RETVAL_OK)
                                 continue;
 
-                        for (i = 0; i < sock_num; i++) {
+			for (i = 0; i < mba_id_num; i++) {
                                 struct pqos_mba mba;
 
-                                ret = resctrl_schemata_mba_get(schmt, sock[i],
-                                                               &mba);
+				ret = resctrl_schemata_mba_get(schmt,
+							       mba_ids[i],
+							       &mba);
                                 if (ret == PQOS_RETVAL_OK && mba.mb_max > 100) {
                                         *enabled = 1;
                                         break;
@@ -797,7 +798,7 @@ os_cap_get_mba_ctrl(const struct pqos_cap *cap,
                 }
 
                 resctrl_schemata_free(schmt);
-                free(sock);
+		free(mba_ids);
         }
 
         /* get free COS and try to write value above 100 */

--- a/lib/pqos.h
+++ b/lib/pqos.h
@@ -1019,6 +1019,20 @@ unsigned *
 pqos_pid_get_pid_assoc(const unsigned class_id, unsigned *count);
 
 /**
+ * @brief Retrieves one core id from cpu info structure for \a mba_id
+ *
+ * @param [in] cpu CPU information structure from \a pqos_cap_get
+ * @param [in] mba to enumerate
+ * @param [out] lcore place to store returned core id
+ *
+ * @return Operation status
+ * @retval PQOS_RETVAL_OK on success
+ */
+int
+pqos_cpu_get_one_by_mba_id(const struct pqos_cpuinfo *cpu,
+			    const unsigned mba_id,
+			    unsigned *lcore);
+/**
  * @brief Retrieves core information from cpu info structure for \a lcore
  *
  * @param [in] cpu CPU information structure from \a pqos_cap_get

--- a/lib/pqos.h
+++ b/lib/pqos.h
@@ -758,23 +758,23 @@ struct pqos_l3ca {
 };
 
 /**
- * @brief Sets classes of service defined by \a ca on \a socket
+ * @brief Sets classes of service defined by \a ca on \a l3cat_id
  *
- * @param [in] socket CPU socket id
+ * @param [in] l3cat_id L3 CAT resource id
  * @param [in] num_cos number of classes of service at \a ca
  * @param [in] ca table with class of service definitions
  *
  * @return Operations status
  * @retval PQOS_RETVAL_OK on success
  */
-int pqos_l3ca_set(const unsigned socket,
+int pqos_l3ca_set(const unsigned l3cat_id,
                   const unsigned num_cos,
                   const struct pqos_l3ca *ca);
 
 /**
  * @brief Reads classes of service from \a socket
  *
- * @param [in] socket CPU socket id
+ * @param [in] l3cat_id L3 CAT resource id
  * @param [in] max_num_ca maximum number of classes of service
  *             that can be accommodated at \a ca
  * @param [out] num_ca number of classes of service read into \a ca
@@ -783,7 +783,7 @@ int pqos_l3ca_set(const unsigned socket,
  * @return Operations status
  * @retval PQOS_RETVAL_OK on success
  */
-int pqos_l3ca_get(const unsigned socket,
+int pqos_l3ca_get(const unsigned l3cat_id,
                   const unsigned max_num_ca,
                   unsigned *num_ca,
                   struct pqos_l3ca *ca);
@@ -884,9 +884,9 @@ struct pqos_mba {
 };
 
 /**
- * @brief Sets classes of service defined by \a mba on \a socket
+ * @brief Sets classes of service defined by \a mba on \a mba id
  *
- * @param [in]  socket CPU socket id
+ * @param [in]  mba_id MBA resource id
  * @param [in]  num_cos number of classes of service at \a ca
  * @param [in]  requested table with class of service definitions
  * @param [out] actual table with class of service definitions
@@ -894,15 +894,15 @@ struct pqos_mba {
  * @return Operations status
  * @retval PQOS_RETVAL_OK on success
  */
-int pqos_mba_set(const unsigned socket,
+int pqos_mba_set(const unsigned mba_id,
                  const unsigned num_cos,
                  const struct pqos_mba *requested,
                  struct pqos_mba *actual);
 
 /**
- * @brief Reads MBA from \a socket
+ * @brief Reads MBA from \a mba_id
  *
- * @param [in]  socket CPU socket id
+ * @param [in]  mba_id MBA resource id
  * @param [in]  max_num_cos maximum number of classes of service
  *              that can be accommodated at \a mba_tab
  * @param [out] num_cos number of classes of service read into \a mba_tab
@@ -911,7 +911,7 @@ int pqos_mba_set(const unsigned socket,
  * @return Operations status
  * @retval PQOS_RETVAL_OK on success
  */
-int pqos_mba_get(const unsigned socket,
+int pqos_mba_get(const unsigned mba_id,
                  const unsigned max_num_cos,
                  unsigned *num_cos,
                  struct pqos_mba *mba_tab);

--- a/lib/pqos.h
+++ b/lib/pqos.h
@@ -923,6 +923,19 @@ int pqos_mba_get(const unsigned socket,
  */
 
 /**
+ * @brief Retrieves l3cat id's from cpu info structure
+ *
+ * @param [in] cpu CPU information structure from \a pqos_cap_get
+ * @param [out] count place to store actual number of l3cat ids returned
+ *
+ * @return Allocated array of size \a count populated with l3cat id's
+ * @retval NULL on error
+ */
+unsigned *
+pqos_cpu_get_l3cat_ids(const struct pqos_cpuinfo *cpu,
+		       unsigned *count);
+
+/**
  * @brief Retrieves socket id's from cpu info structure
  *
  * @param [in] cpu CPU information structure from \a pqos_cap_get

--- a/lib/pqos.h
+++ b/lib/pqos.h
@@ -923,6 +923,19 @@ int pqos_mba_get(const unsigned socket,
  */
 
 /**
+ * @brief Retrieves mba id's from cpu info structure
+ *
+ * @param [in] cpu CPU information structure from \a pqos_cap_get
+ * @param [out] count place to store actual number of mba ids returned
+ *
+ * @return Allocated array of size \a count populated with mba id's
+ * @retval NULL on error
+ */
+unsigned *
+pqos_cpu_get_mba_ids(const struct pqos_cpuinfo *cpu,
+		     unsigned *count);
+
+/**
  * @brief Retrieves l3cat id's from cpu info structure
  *
  * @param [in] cpu CPU information structure from \a pqos_cap_get

--- a/lib/pqos.h
+++ b/lib/pqos.h
@@ -1046,6 +1046,20 @@ pqos_cpu_get_one_core(const struct pqos_cpuinfo *cpu,
                       unsigned *lcore);
 
 /**
+ * @brief Retrieves one core id from cpu info structure for \a l3cat id
+ *
+ * @param [in] cpu CPU information structure from \a pqos_cap_get
+ * @param [in] l3cat id to enumerate
+ * @param [out] lcore place to store returned core id
+ *
+ * @return Operation status
+ * @retval PQOS_RETVAL_OK on success
+ */
+int
+pqos_cpu_get_one_by_l3cat_id(const struct pqos_cpuinfo *cpu,
+			      const unsigned l3cat_id,
+			      unsigned *lcore);
+/**
  * @brief Retrieves one core id from cpu info structure for \a l2id
  *
  * @param [in] cpu CPU information structure from \a pqos_cap_get

--- a/lib/pqos.h
+++ b/lib/pqos.h
@@ -309,6 +309,8 @@ struct pqos_coreinfo {
         unsigned socket;                /**< socket id in the system */
         unsigned l3_id;                 /**< L3/LLC cluster id */
         unsigned l2_id;                 /**< L2 cluster id */
+	unsigned l3cat_id;              /**< L3 CAT classes id */
+	unsigned mba_id;                /**< MBA id */
 };
 
 /**

--- a/lib/resctrl_monitoring.c
+++ b/lib/resctrl_monitoring.c
@@ -347,9 +347,9 @@ resctrl_mon_read_counters(const unsigned class_id,
                  uint64_t *value)
 {
         int ret = PQOS_RETVAL_OK;
-        unsigned *sockets = NULL;
-        unsigned sockets_num;
-        unsigned socket;
+	unsigned *l3cat_ids = NULL;
+	unsigned l3cat_id_num;
+	unsigned l3cat_id;
         char buf[128];
         const char *name;
 
@@ -376,19 +376,19 @@ resctrl_mon_read_counters(const unsigned class_id,
 
         resctrl_mon_group_path(class_id, resctrl_group, NULL, buf, sizeof(buf));
 
-        sockets = pqos_cpu_get_sockets(m_cpu, &sockets_num);
-        if (sockets == NULL) {
+	l3cat_ids = pqos_cpu_get_l3cat_ids(m_cpu, &l3cat_id_num);
+	if (l3cat_ids == NULL) {
                 ret = PQOS_RETVAL_ERROR;
                 goto resctrl_mon_read_exit;
         }
 
-        for (socket = 0; socket < sockets_num; socket++) {
+	for (l3cat_id = 0; l3cat_id < l3cat_id_num; l3cat_id++) {
                 char path[PATH_MAX];
                 FILE *fd;
                 unsigned long long counter;
 
                 snprintf(path, sizeof(path), "%s/mon_data/mon_L3_%02u/%s", buf,
-                         sockets[socket], name);
+			 l3cat_ids[l3cat_id], name);
                 fd = fopen_check_symlink(path, "r");
                 if (fd == NULL) {
                         ret = PQOS_RETVAL_ERROR;
@@ -400,8 +400,8 @@ resctrl_mon_read_counters(const unsigned class_id,
         }
 
  resctrl_mon_read_exit:
-        if (sockets != NULL)
-                free(sockets);
+	if (l3cat_ids != NULL)
+		free(l3cat_ids);
 
         return ret;
 }

--- a/lib/resctrl_schemata.c
+++ b/lib/resctrl_schemata.c
@@ -104,8 +104,8 @@ resctrl_schemata_alloc(const struct pqos_cap *cap,
         /* L3 */
         retval = pqos_cap_get_type(cap, PQOS_CAP_TYPE_L3CA, &cap_l3ca);
         if (retval == PQOS_RETVAL_OK && cap_l3ca != NULL) {
-                schemata->l3ids = pqos_cpu_get_sockets(cpu,
-                                                       &schemata->l3ids_num);
+		schemata->l3ids = pqos_cpu_get_l3cat_ids(cpu,
+							 &schemata->l3ids_num);
                 if (schemata->l3ids == NULL)
                         goto resctrl_schemata_alloc_error;
 

--- a/lib/utils.c
+++ b/lib/utils.c
@@ -67,6 +67,44 @@ _pqos_utils_init(int interface)
 }
 
 unsigned *
+pqos_cpu_get_mba_ids(const struct pqos_cpuinfo *cpu,
+		     unsigned *count)
+{
+	unsigned mba_id_count = 0, i = 0;
+	unsigned *mba_ids = NULL;
+
+	ASSERT(cpu != NULL);
+	ASSERT(count != NULL);
+	if (cpu == NULL || count == NULL)
+		return NULL;
+
+	mba_ids = (unsigned *) malloc(sizeof(mba_ids[0]) * cpu->num_cores);
+	if (mba_ids == NULL)
+		return NULL;
+
+	for (i = 0; i < cpu->num_cores; i++) {
+		unsigned j = 0;
+
+		/**
+		 * Check if this mba id is already on the \a mbas list
+		 */
+		for (j = 0; j < mba_id_count && mba_id_count > 0; j++)
+			if (cpu->cores[i].mba_id  == mba_ids[j])
+				break;
+
+		if (j >= mba_id_count || mba_id_count == 0) {
+			/**
+			 * This mba_id wasn't reported before
+			 */
+			mba_ids[mba_id_count++] = cpu->cores[i].mba_id;
+		}
+	}
+
+	*count = mba_id_count;
+	return mba_ids;
+}
+
+unsigned *
 pqos_cpu_get_l3cat_ids(const struct pqos_cpuinfo *cpu,
 		       unsigned *count)
 {

--- a/lib/utils.c
+++ b/lib/utils.c
@@ -346,6 +346,28 @@ pqos_cpu_get_one_core(const struct pqos_cpuinfo *cpu,
 }
 
 int
+pqos_cpu_get_one_by_l3cat_id(const struct pqos_cpuinfo *cpu,
+			      const unsigned l3cat_id,
+			      unsigned *lcore)
+{
+	unsigned i = 0;
+
+	ASSERT(cpu != NULL);
+	ASSERT(lcore != NULL);
+
+	if (cpu == NULL || lcore == NULL)
+		return PQOS_RETVAL_PARAM;
+
+	for (i = 0; i < cpu->num_cores; i++)
+		if (cpu->cores[i].l3cat_id == l3cat_id) {
+			*lcore = cpu->cores[i].lcore;
+			return PQOS_RETVAL_OK;
+		}
+
+	return PQOS_RETVAL_ERROR;
+}
+
+int
 pqos_cpu_get_one_by_l2id(const struct pqos_cpuinfo *cpu,
                          const unsigned l2id,
                          unsigned *lcore)

--- a/lib/utils.c
+++ b/lib/utils.c
@@ -66,6 +66,43 @@ _pqos_utils_init(int interface)
         return PQOS_RETVAL_OK;
 }
 
+unsigned *
+pqos_cpu_get_l3cat_ids(const struct pqos_cpuinfo *cpu,
+		       unsigned *count)
+{
+	unsigned l3cat_count = 0, i = 0;
+	unsigned *l3cat_ids = NULL;
+
+	ASSERT(cpu != NULL);
+	ASSERT(count != NULL);
+	if (cpu == NULL || count == NULL)
+		return NULL;
+
+	l3cat_ids = (unsigned *) malloc(sizeof(l3cat_ids[0]) * cpu->num_cores);
+	if (l3cat_ids == NULL)
+		return NULL;
+
+	for (i = 0; i < cpu->num_cores; i++) {
+		unsigned j = 0;
+
+		/**
+		 * Check if this l3cat id is already on the \a l3cat_ids list
+		 */
+		for (j = 0; j < l3cat_count && l3cat_count > 0; j++)
+			if (cpu->cores[i].l3cat_id  == l3cat_ids[j])
+				break;
+
+		if (j >= l3cat_count || l3cat_count == 0) {
+			/**
+			 * This l3cat_id wasn't reported before
+			 */
+			l3cat_ids[l3cat_count++] = cpu->cores[i].l3cat_id;
+		}
+	}
+
+	*count = l3cat_count;
+	return l3cat_ids;
+}
 
 unsigned *
 pqos_cpu_get_sockets(const struct pqos_cpuinfo *cpu,

--- a/lib/utils.c
+++ b/lib/utils.c
@@ -368,6 +368,28 @@ pqos_cpu_get_one_by_l3cat_id(const struct pqos_cpuinfo *cpu,
 }
 
 int
+pqos_cpu_get_one_by_mba_id(const struct pqos_cpuinfo *cpu,
+			    const unsigned mba_id,
+			    unsigned *lcore)
+{
+	unsigned i = 0;
+
+	ASSERT(cpu != NULL);
+	ASSERT(lcore != NULL);
+
+	if (cpu == NULL || lcore == NULL)
+		return PQOS_RETVAL_PARAM;
+
+	for (i = 0; i < cpu->num_cores; i++)
+		if (cpu->cores[i].mba_id == mba_id) {
+			*lcore = cpu->cores[i].lcore;
+			return PQOS_RETVAL_OK;
+		}
+
+	return PQOS_RETVAL_ERROR;
+}
+
+int
 pqos_cpu_get_one_by_l2id(const struct pqos_cpuinfo *cpu,
                          const unsigned l2id,
                          unsigned *lcore)

--- a/pqos/alloc.c
+++ b/pqos/alloc.c
@@ -470,7 +470,7 @@ set_allocation_cos(char *str, unsigned *res_ids,
         }
         /* set L3 CAT classes */
         if (ids == NULL)
-                ids = pqos_cpu_get_sockets(cpu, &n);
+		ids = pqos_cpu_get_l3cat_ids(cpu, &n);
         if (ids == NULL) {
                 printf("Failed to retrieve socket info!\n");
                 return -1;

--- a/pqos/alloc.c
+++ b/pqos/alloc.c
@@ -444,7 +444,7 @@ set_allocation_cos(char *str, unsigned *res_ids,
                 int ctrl = (type == MBA_CTRL) ? 1 : 0;
 
                 if (ids == NULL)
-                        ids = pqos_cpu_get_sockets(cpu, &n);
+			ids = pqos_cpu_get_mba_ids(cpu, &n);
                 if (ids == NULL) {
                         printf("Failed to retrieve socket info!\n");
                         return -1;

--- a/pqos/main.c
+++ b/pqos/main.c
@@ -715,7 +715,7 @@ int main(int argc, char **argv)
         const struct pqos_cap *p_cap = NULL;
         const struct pqos_capability *cap_mon = NULL, *cap_l3ca = NULL,
                 *cap_l2ca = NULL, *cap_mba = NULL;
-        unsigned sock_count, *sockets = NULL;
+	unsigned l3cat_id_count, *l3cat_ids = NULL;
         int cmd, ret, exit_val = EXIT_SUCCESS;
         int opt_index = 0, pid_flag = 0;
 
@@ -906,8 +906,8 @@ int main(int argc, char **argv)
                 goto error_exit_2;
         }
 
-        sockets = pqos_cpu_get_sockets(p_cpu, &sock_count);
-        if (sockets == NULL) {
+	l3cat_ids = pqos_cpu_get_l3cat_ids(p_cpu, &l3cat_id_count);
+	if (l3cat_ids == NULL) {
                 printf("Error retrieving CPU socket information!\n");
                 exit_val = EXIT_FAILURE;
                 goto error_exit_2;
@@ -982,7 +982,7 @@ int main(int argc, char **argv)
                  * Show info about allocation config and exit
                  */
 		alloc_print_config(cap_mon, cap_l3ca, cap_l2ca, cap_mba,
-                                   sock_count, sockets, p_cpu,
+				   l3cat_id_count, l3cat_ids, p_cpu,
                                    sel_verbose_mode);
                 goto allocation_exit;
         }
@@ -1062,8 +1062,8 @@ int main(int argc, char **argv)
                 free(sel_log_file);
         if (sel_config_file != NULL)
                 free(sel_config_file);
-        if (sockets != NULL)
-                free(sockets);
+	if (l3cat_ids != NULL)
+		free(l3cat_ids);
 
         return exit_val;
 }

--- a/rdtset/common.h
+++ b/rdtset/common.h
@@ -47,6 +47,11 @@ extern "C" {
 #define RDT_MAX_PIDS    128
 #define MAX_OPTARG_LEN  64
 
+/**
+ * MBA linear max value.
+ */
+#define RDT_MAX_MBA	100
+
 #ifndef MIN
 /**
  * Macro to return the minimum of two numbers

--- a/rdtset/rdt.c
+++ b/rdtset/rdt.c
@@ -258,8 +258,7 @@ get_max_res_id(unsigned technology, unsigned *max_res_id)
                 free(ids);
         }
 	/* get number of l3cat_ids */
-        if (technology & (1 << PQOS_CAP_TYPE_L3CA) ||
-            technology & (1 << PQOS_CAP_TYPE_MBA)) {
+	if (technology & (1 << PQOS_CAP_TYPE_L3CA)) {
 		ids = pqos_cpu_get_l3cat_ids(m_cpu, &num_ids);
                 if (ids == NULL)
                         return -EFAULT;
@@ -269,6 +268,18 @@ get_max_res_id(unsigned technology, unsigned *max_res_id)
 
                 free(ids);
         }
+
+	/* get number of mba_ids */
+	if (technology & (1 << PQOS_CAP_TYPE_MBA)) {
+		ids = pqos_cpu_get_mba_ids(m_cpu, &num_ids);
+		if (ids == NULL)
+			return -EFAULT;
+
+		for (i = 0; i < num_ids; i++)
+			max = ids[i] > max ? ids[i] : max;
+
+		free(ids);
+	}
 
         *max_res_id = max;
         return 0;

--- a/rdtset/rdt.c
+++ b/rdtset/rdt.c
@@ -229,7 +229,7 @@ is_contiguous(const char *cat_type, const uint64_t bitmask)
 /**
  * @brief Function to get the highest resource ID (socket/cluster)
  *
- * @param [in] technology used to determine if res ID should be socket or
+ * @param [in] technology used to determine if res ID should be l3cat_id or
  *             cluster
  * @param [out] max_res_id the highest possible resource ID
  *
@@ -257,10 +257,10 @@ get_max_res_id(unsigned technology, unsigned *max_res_id)
 
                 free(ids);
         }
-        /* get number of sockets */
+	/* get number of l3cat_ids */
         if (technology & (1 << PQOS_CAP_TYPE_L3CA) ||
             technology & (1 << PQOS_CAP_TYPE_MBA)) {
-                ids = pqos_cpu_get_sockets(m_cpu, &num_ids);
+		ids = pqos_cpu_get_l3cat_ids(m_cpu, &num_ids);
                 if (ids == NULL)
                         return -EFAULT;
 

--- a/rdtset/rdt.c
+++ b/rdtset/rdt.c
@@ -160,8 +160,9 @@ rdt_cfg_is_valid(const struct rdt_cfg cfg)
 
 	case PQOS_CAP_TYPE_MBA:
 		return cfg.u.mba != NULL && cfg.u.mba->mb_max > 0 &&
-			((cfg.u.mba->ctrl == 0 && cfg.u.mba->mb_max <= 100) ||
-			cfg.u.mba->ctrl == 1);
+			((cfg.u.mba->ctrl == 0 &&
+			  cfg.u.mba->mb_max <= RDT_MAX_MBA) ||
+			  cfg.u.mba->ctrl == 1);
 
 	default:
 		break;
@@ -444,7 +445,7 @@ rdt_mba_str_to_rate(const char *param, struct rdt_cfg mba)
 		return -EINVAL;
 
 	ret = str_to_uint64(param, 10, &rate);
-	if (ret < 0 || rate == 0 || rate > 100)
+	if (ret < 0 || rate == 0 || rate > RDT_MAX_MBA)
 		return -EINVAL;
 
 	mba.u.mba->ctrl = 0;
@@ -1264,7 +1265,7 @@ alloc_get_default_cos(struct pqos_l2ca *l2_def, struct pqos_l3ca *l3_def,
 			mba_def->ctrl = 1;
 			mba_def->mb_max = UINT32_MAX;
 		} else
-			mba_def->mb_max = 100;
+			mba_def->mb_max = RDT_MAX_MBA;
 	}
 
 	return 0;
@@ -1362,7 +1363,7 @@ cfg_configure_cos(const struct pqos_l2ca *l2ca, const struct pqos_l3ca *l3ca,
 		if (!rdt_cfg_is_valid(wrap_mba(&mba_requested)))
 			mba_requested = mba_defs;
 		else if (mba_sc_mode(&g_cfg)) {
-			mba_requested.mb_max = MBA_SC_DEF_INIT_MBA;
+			mba_requested.mb_max = RDT_MAX_MBA;
 			mba_requested.ctrl = 0;
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Support AMD processors in cmt-cat tool

## Description
AMD is working on to support RDT feature(AMD calls it QoS feature) in next generation hardware. Right now the tool intel-cmt-cat does not support AMD. Majority of these features are similar in both the vendors. However, there are some differences in the way some of these features are implemented in each vendor. We needed to separate those functions and define the vendor specific versions of these functions. This pull request is a first attempt in that direction.

The specification for this AMD feature is available at
https://developer.amd.com/wp-content/resources/56375.pdf

## Affected parts
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] library
- [X] pqos utility
- [X] rdtset utility
- [ ] other: (please specify)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Idea here is to have a one tool to support both Intel and AMD. It becomes easy to maintain one tool for both the vendors. It also benefits the OS vendors.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

This pull request only has partial set of changes. These patches does not add AMD support yet. So, I have tested on Intel box to make sure it does not introduce any regressions.
Hardware configuration of the Intel system.

lscpu

Architecture: x86_64
CPU op-mode(s): 32-bit, 64-bit
Byte Order: Little Endian
Address sizes: 46 bits physical, 48 bits virtual
CPU(s): 32
On-line CPU(s) list: 0-31
Thread(s) per core: 2
Core(s) per socket: 16
Socket(s): 1
NUMA node(s): 1
Vendor ID: GenuineIntel
CPU family: 6
Model: 85
Model name: Intel(R) Xeon(R) Gold 5218 CPU @ 2.30GHz
Stepping: 7
CPU MHz: 1001.145
CPU max MHz: 3900.0000
CPU min MHz: 1000.0000
BogoMIPS: 4600.00
Virtualization: VT-x
L1d cache: 32K
L1i cache: 32K
L2 cache: 1024K
L3 cache: 22528K
NUMA node0 CPU(s): 0-31
Flags: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge
mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall
nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl
xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl
vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid dca sse4_1 sse4_2
x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm
abm 3dnowprefetch cpuid_fault epb cat_l3 cdp_l3 invpcid_single intel_ppin
ssbd mba ibrs ibpb stibp ibrs_enhanced tpr_shadow vnmi flexpriority ept
vpid ept_ad fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 erms invpcid rtm
cqm mpx rdt_a avx512f avx512dq rdseed adx smap clflushopt clwb intel_pt
avx512cd avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves cqm_llc
cqm_occup_llc cqm_mbm_total cqm_mbm_local dtherm ida arat pln pts pku
ospke avx512_vnni md_clear flush_l1d arch_capabilities

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
User interface for the tool has not changed. So old documentation still holds good. But we may need to update the doc once the AMD support is fully integrated.