### PR TITLE
Amd v10 pull

### DIFF
--- a/examples/c/CAT_MBA/allocation_app_l2cat.c
+++ b/examples/c/CAT_MBA/allocation_app_l2cat.c
@@ -180,6 +180,7 @@ print_allocation_config(const unsigned l2_count,
 	}
 	return ret;
 }
+
 int main(int argc, char *argv[])
 {
 	struct pqos_config cfg;

--- a/examples/c/CAT_MBA/allocation_app_l3cat.c
+++ b/examples/c/CAT_MBA/allocation_app_l3cat.c
@@ -145,30 +145,30 @@ set_allocation_class(unsigned sock_count,
 }
 /**
  * @brief Prints allocation configuration
- * @param sock_count number of CPU sockets
- * @param sockets arrays with CPU socket id's
+ * @param l3cat_id_count number of CPU l3cat_id
+ * @param l3cat_ids arrays with CPU l3cat id's
  *
  * @return PQOS_RETVAL_OK on success
  * @return error value on failure
  */
 static int
-print_allocation_config(const unsigned sock_count,
-                        const unsigned *sockets)
+print_allocation_config(const unsigned l3cat_id_count,
+			const unsigned *l3cat_ids)
 {
 	int ret = PQOS_RETVAL_OK;
 	unsigned i;
 
-	for (i = 0; i < sock_count; i++) {
+	for (i = 0; i < l3cat_id_count; i++) {
 		struct pqos_l3ca tab[PQOS_MAX_L3CA_COS];
 		unsigned num = 0;
 
-		ret = pqos_l3ca_get(sockets[i], PQOS_MAX_L3CA_COS,
+		ret = pqos_l3ca_get(l3cat_ids[i], PQOS_MAX_L3CA_COS,
                                     &num, tab);
 		if (ret == PQOS_RETVAL_OK) {
 			unsigned n = 0;
 
 			printf("L3CA COS definitions for Socket %u:\n",
-                               sockets[i]);
+				l3cat_ids[i]);
 			for (n = 0; n < num; n++) {
 				printf("    L3CA COS%u => MASK 0x%llx\n",
                                        tab[n].class_id,
@@ -181,6 +181,7 @@ print_allocation_config(const unsigned sock_count,
 	}
 	return ret;
 }
+
 int main(int argc, char *argv[])
 {
 	struct pqos_config cfg;

--- a/examples/c/CAT_MBA/allocation_app_l3cat.c
+++ b/examples/c/CAT_MBA/allocation_app_l3cat.c
@@ -113,10 +113,10 @@ allocation_get_input(int argc, char *argv[])
 	}
 }
 /**
- * @brief Sets up allocation classes of service on selected CPU sockets
+ * @brief Sets up allocation classes of service on selected L3 CAT ids
  *
- * @param sock_count number of CPU sockets
- * @param sockets arrays with CPU socket id's
+ * @param l3cat_id_count number of CPU l3cat_ids
+ * @param l3cat_ids arrays with CPU l3cat id's
  *
  * @return Number of classes of service set
  * @retval 0 no class of service set (nor selected)
@@ -124,13 +124,13 @@ allocation_get_input(int argc, char *argv[])
  * @retval positive success
  */
 static int
-set_allocation_class(unsigned sock_count,
-                     const unsigned *sockets)
+set_allocation_class(unsigned l3cat_id_count,
+		     const unsigned *l3cat_ids)
 {
 	int ret;
 
-	while (sock_count > 0 && sel_l3ca_cos_num > 0) {
-		ret = pqos_l3ca_set(*sockets,
+	while (l3cat_id_count > 0 && sel_l3ca_cos_num > 0) {
+		ret = pqos_l3ca_set(*l3cat_ids,
                                     sel_l3ca_cos_num,
                                     sel_l3ca_cos_tab);
 		if  (ret != PQOS_RETVAL_OK) {
@@ -138,8 +138,8 @@ set_allocation_class(unsigned sock_count,
                                "service failed!\n");
 			return -1;
 		}
-		sock_count--;
-		sockets++;
+		l3cat_id_count--;
+		l3cat_ids++;
 	}
 	return sel_l3ca_cos_num;
 }

--- a/examples/c/CAT_MBA/allocation_app_mba.c
+++ b/examples/c/CAT_MBA/allocation_app_mba.c
@@ -121,10 +121,10 @@ allocation_get_input(int argc, char *argv[])
         }
 }
 /**
- * @brief Sets up allocation classes of service on selected CPU sockets
+ * @brief Sets up allocation classes of service on selected MBA ids
  *
- * @param sock_count number of CPU sockets
- * @param sockets arrays with CPU socket id's
+ * @param mba_count number of CPU mba ids
+ * @param mba_ids arrays
  *
  * @return Number of classes of service set
  * @retval 0 no class of service set (nor selected)
@@ -132,13 +132,13 @@ allocation_get_input(int argc, char *argv[])
  * @retval positive success
  */
 static int
-set_allocation_class(unsigned sock_count,
-                     const unsigned *sockets)
+set_allocation_class(unsigned mba_count,
+		     const unsigned *mba_ids)
 {
 	int ret;
 
-	while (sock_count > 0 && sel_mba_cos_num > 0) {
-		ret = pqos_mba_set(*sockets,
+	while (mba_count > 0 && sel_mba_cos_num > 0) {
+		ret = pqos_mba_set(*mba_ids,
                                     sel_mba_cos_num,
                                     &mba[REQUESTED],
                                     &mba[ACTUAL]);
@@ -147,11 +147,11 @@ set_allocation_class(unsigned sock_count,
 			return -1;
 		}
                 printf("SKT%u: MBA COS%u => %u%% requested, %u%% applied\n",
-                       *sockets, mba[REQUESTED].class_id,
-                       mba[REQUESTED].mb_max, mba[ACTUAL].mb_max);
+			*mba_ids, mba[REQUESTED].class_id,
+			mba[REQUESTED].mb_max, mba[ACTUAL].mb_max);
 
-		sock_count--;
-		sockets++;
+		mba_count--;
+		mba_ids++;
 	}
 
 	return sel_mba_cos_num;

--- a/examples/c/CAT_MBA/allocation_app_mba.c
+++ b/examples/c/CAT_MBA/allocation_app_mba.c
@@ -166,8 +166,8 @@ set_allocation_class(unsigned sock_count,
  */
 static int
 print_allocation_config(const struct pqos_cap *p_cap,
-                        const unsigned sock_count,
-                        const unsigned *sockets)
+			    const unsigned mba_count,
+			    const unsigned *mba_ids)
 {
         const struct pqos_capability *cap = NULL;
         const struct pqos_cap_mba *mba_cap = NULL;
@@ -180,17 +180,17 @@ print_allocation_config(const struct pqos_cap *p_cap,
                 return ret;
         mba_cap = cap->u.mba;
 
-	for (i = 0; i < sock_count; i++) {
+	for (i = 0; i < mba_count; i++) {
                 struct pqos_mba tab[mba_cap->num_classes];
 	        unsigned num = 0;
 
-		ret = pqos_mba_get(sockets[i], mba_cap->num_classes,
+		ret = pqos_mba_get(mba_ids[i], mba_cap->num_classes,
                                    &num, tab);
 		if (ret == PQOS_RETVAL_OK) {
 			unsigned n = 0;
 
                         printf("MBA COS definitions for Socket %u:\n",
-                               sockets[i]);
+			       mba_ids[i]);
 			for (n = 0; n < num; n++) {
 				printf("    MBA COS%u => %u%% available\n",
                                        tab[n].class_id,

--- a/examples/c/CAT_MBA/association_app.c
+++ b/examples/c/CAT_MBA/association_app.c
@@ -124,7 +124,8 @@ print_allocation_config(void)
 		unsigned *lcores = NULL;
 		unsigned lcount = 0, n = 0;
 
-		lcores = pqos_cpu_get_cores(p_cpu, l3cat_ids[i], &lcount);
+		lcores = pqos_cpu_get_cores_l3cat_id(p_cpu, l3cat_ids[i],
+						     &lcount);
 		if (lcores == NULL || lcount == 0) {
 			printf("Error retrieving core information!\n");
                         free(lcores);

--- a/examples/c/CAT_MBA/reset_app.c
+++ b/examples/c/CAT_MBA/reset_app.c
@@ -89,7 +89,8 @@ print_allocation_config(const struct pqos_capability *cap_l3ca,
 		unsigned *lcores = NULL;
 		unsigned lcount = 0, n = 0;
 
-		lcores = pqos_cpu_get_cores(cpu_info, l3cat_ids[i], &lcount);
+		lcores = pqos_cpu_get_cores_l3cat_id(cpu_info, l3cat_ids[i],
+						     &lcount);
 		if (lcores == NULL || lcount == 0) {
 			printf("Error retrieving core information!\n");
                         free(lcores);

--- a/examples/c/CAT_MBA/reset_app.c
+++ b/examples/c/CAT_MBA/reset_app.c
@@ -56,9 +56,9 @@
  */
 static void
 print_allocation_config(const struct pqos_capability *cap_l3ca,
-                        const unsigned sock_count,
-                        const unsigned *sockets,
-                        const struct pqos_cpuinfo *cpu_info)
+			      const unsigned l3cat_id_count,
+			      const unsigned *l3cat_ids,
+			      const struct pqos_cpuinfo *cpu_info)
 {
 	int ret;
 	unsigned i;
@@ -66,17 +66,17 @@ print_allocation_config(const struct pqos_capability *cap_l3ca,
 	if (cap_l3ca == NULL)
                 return;
 
-        for (i = 0; i < sock_count; i++) {
+	for (i = 0; i < l3cat_id_count; i++) {
                 struct pqos_l3ca tab[PQOS_MAX_L3CA_COS];
                 unsigned num = 0;
 
-                ret = pqos_l3ca_get(sockets[i], PQOS_MAX_L3CA_COS,
+		ret = pqos_l3ca_get(l3cat_ids[i], PQOS_MAX_L3CA_COS,
                                     &num, tab);
                 if (ret == PQOS_RETVAL_OK) {
                         unsigned n = 0;
 
                         printf("L3CA COS definitions for Socket %u:\n",
-                               sockets[i]);
+				l3cat_ids[i]);
                         for (n = 0; n < num; n++) {
                                 printf("   L3CA COS%u => MASK 0x%llx\n",
                                        tab[n].class_id,
@@ -85,18 +85,18 @@ print_allocation_config(const struct pqos_capability *cap_l3ca,
                 }
         }
 
-	for (i = 0; i < sock_count; i++) {
+	for (i = 0; i < l3cat_id_count; i++) {
 		unsigned *lcores = NULL;
 		unsigned lcount = 0, n = 0;
 
-		lcores = pqos_cpu_get_cores(cpu_info, sockets[i], &lcount);
+		lcores = pqos_cpu_get_cores(cpu_info, l3cat_ids[i], &lcount);
 		if (lcores == NULL || lcount == 0) {
 			printf("Error retrieving core information!\n");
                         free(lcores);
 			return;
 		}
 		printf("Core information for socket %u:\n",
-                       sockets[i]);
+			l3cat_ids[i]);
 		for (n = 0; n < lcount; n++) {
 			unsigned class_id = 0;
 			int ret1 = PQOS_RETVAL_OK;

--- a/lib/allocation.c
+++ b/lib/allocation.c
@@ -185,6 +185,10 @@ cos_assoc_get(const unsigned lcore, unsigned *class_id)
  * @param [in] technology selection of allocation technologies
  * @param [out] class_id unused COS
  *
+ * NOTE: It is our assumption that mba id and cat ids are same for
+ * a core. In future, if a core can have different mba id and cat ids
+ * then, we need to change this function to handle it.
+ *
  * @return Operation status
  */
 static int
@@ -193,6 +197,7 @@ get_unused_cos(const unsigned id,
                unsigned *class_id)
 {
         const int l2_req = ((technology & (1 << PQOS_CAP_TYPE_L2CA)) != 0);
+	const int mba_req = ((technology & (1 << PQOS_CAP_TYPE_MBA)) != 0);
         unsigned used_classes[PQOS_MAX_L3CA_COS];
         unsigned i, cos;
 	unsigned hi_class_id;
@@ -210,14 +215,17 @@ get_unused_cos(const unsigned id,
 
         /* Create a list of COS used on socket/L2 cluster */
         for (i = 0; i < m_cpu->num_cores; i++) {
-
                 if (l2_req) {
                         /* L2 requested so looking in L2 cluster scope */
                         if (m_cpu->cores[i].l2_id != id)
                                 continue;
+		} else if (mba_req) {
+			/* mba requested so looking in mba_id scope */
+			if (m_cpu->cores[i].mba_id != id)
+				continue;
                 } else {
-                        /* L2 not requested so looking at socket scope */
-                        if (m_cpu->cores[i].socket != id)
+			/* looking at l3cat_id scope */
+			if (m_cpu->cores[i].l3cat_id != id)
                                 continue;
                 }
 
@@ -1085,8 +1093,9 @@ hw_alloc_assign(const unsigned technology,
                 unsigned *class_id)
 {
         const int l2_req = ((technology & (1 << PQOS_CAP_TYPE_L2CA)) != 0);
+	const int mba_req = ((technology & (1 << PQOS_CAP_TYPE_MBA)) != 0);
+	unsigned l3cat_id = 0, l2id = 0, mba_id = 0;
         unsigned i;
-        unsigned socket = 0, l2id = 0;
         int ret;
 
         ASSERT(core_num > 0);
@@ -1113,20 +1122,29 @@ hw_alloc_assign(const unsigned technology,
                                 goto pqos_alloc_assign_exit;
                         }
                         l2id = pi->l2_id;
-                } else {
-                        if (i != 0 && socket != pi->socket) {
+		} else if (mba_req) {
+			if (i != 0 && mba_id != pi->mba_id) {
+				ret = PQOS_RETVAL_PARAM;
+				goto pqos_alloc_assign_exit;
+			}
+			mba_id = pi->mba_id;
+		} else {
+			if (i != 0 && l3cat_id != pi->l3cat_id) {
                                 ret = PQOS_RETVAL_PARAM;
                                 goto pqos_alloc_assign_exit;
                         }
-                        socket = pi->socket;
+			l3cat_id = pi->l3cat_id;
                 }
         }
 
         /* find an unused class from highest down */
-        if (!l2_req)
-                ret = get_unused_cos(socket, technology, class_id);
-        else
-                ret = get_unused_cos(l2id, technology, class_id);
+	if (l2_req)
+		ret = get_unused_cos(l2id, 1 << PQOS_CAP_TYPE_L2CA, class_id);
+	else if (mba_req)
+		ret = get_unused_cos(mba_id, 1 << PQOS_CAP_TYPE_MBA, class_id);
+	else
+		ret = get_unused_cos(l3cat_id, 1 << PQOS_CAP_TYPE_L3CA,
+				     class_id);
 
         if (ret != PQOS_RETVAL_OK)
                 goto pqos_alloc_assign_exit;

--- a/lib/allocation.c
+++ b/lib/allocation.c
@@ -1094,7 +1094,7 @@ hw_alloc_assign(const unsigned technology,
 {
         const int l2_req = ((technology & (1 << PQOS_CAP_TYPE_L2CA)) != 0);
 	const int mba_req = ((technology & (1 << PQOS_CAP_TYPE_MBA)) != 0);
-	unsigned l3cat_id = 0, l2id = 0, mba_id = 0;
+	unsigned resource_id = 0;
         unsigned i;
         int ret;
 
@@ -1117,34 +1117,28 @@ hw_alloc_assign(const unsigned technology,
                         /* L2 is requested
                          * The smallest manageable entity is L2 cluster
                          */
-                        if (i != 0 && l2id != pi->l2_id) {
+                        if (i != 0 && resource_id != pi->l2_id) {
                                 ret = PQOS_RETVAL_PARAM;
                                 goto pqos_alloc_assign_exit;
                         }
-                        l2id = pi->l2_id;
+                        resource_id = pi->l2_id;
 		} else if (mba_req) {
-			if (i != 0 && mba_id != pi->mba_id) {
+			if (i != 0 && resource_id != pi->mba_id) {
 				ret = PQOS_RETVAL_PARAM;
 				goto pqos_alloc_assign_exit;
 			}
-			mba_id = pi->mba_id;
+			resource_id = pi->mba_id;
 		} else {
-			if (i != 0 && l3cat_id != pi->l3cat_id) {
+			if (i != 0 && resource_id != pi->l3cat_id) {
                                 ret = PQOS_RETVAL_PARAM;
                                 goto pqos_alloc_assign_exit;
                         }
-			l3cat_id = pi->l3cat_id;
+			resource_id = pi->l3cat_id;
                 }
         }
 
         /* find an unused class from highest down */
-	if (l2_req)
-		ret = get_unused_cos(l2id, 1 << PQOS_CAP_TYPE_L2CA, class_id);
-	else if (mba_req)
-		ret = get_unused_cos(mba_id, 1 << PQOS_CAP_TYPE_MBA, class_id);
-	else
-		ret = get_unused_cos(l3cat_id, 1 << PQOS_CAP_TYPE_L3CA,
-				     class_id);
+	ret = get_unused_cos(resource_id, technology, class_id);
 
         if (ret != PQOS_RETVAL_OK)
                 goto pqos_alloc_assign_exit;

--- a/lib/machine.h
+++ b/lib/machine.h
@@ -53,6 +53,9 @@ extern "C" {
 #define MACHINE_RETVAL_ERROR        1         /**< generic error */
 #define MACHINE_RETVAL_PARAM        2         /**< parameter error */
 
+/* cpuid leaf for cache topology */
+#define CPUID_LEAF_CACHE	    4
+
 /**
  * Results of CPUID operation are stored in this structure.
  * It consists of 4x32bits IA registers: EAX, EBX, ECX and EDX.

--- a/lib/pqos.h
+++ b/lib/pqos.h
@@ -1007,6 +1007,20 @@ pqos_cpu_get_cores(const struct pqos_cpuinfo *cpu,
                    unsigned *count);
 
 /**
+ * @brief Retrieves core id's from cpu info structure for \a l3cat_id
+ *
+ * @param [in] cpu CPU information structure from \a pqos_cap_get
+ * @param [in] l3cat_id to enumerate
+ * @param [out] count place to store actual number of core id's returned
+ *
+ * @return Allocated core id array
+ * @retval NULL on error
+ */
+unsigned *
+pqos_cpu_get_cores_l3cat_id(const struct pqos_cpuinfo *cpu,
+			    const unsigned l3cat_id, unsigned *count);
+
+/**
  * @brief Retrieves task id's from resctrl task file for a given COS
  *
  * @param [in] class_id Class of Service ID

--- a/lib/utils.c
+++ b/lib/utils.c
@@ -306,6 +306,37 @@ pqos_cpu_get_cores(const struct pqos_cpuinfo *cpu,
         return cores;
 }
 
+unsigned *
+pqos_cpu_get_cores_l3cat_id(const struct pqos_cpuinfo *cpu,
+			    const unsigned l3cat_id,
+			    unsigned *count)
+{
+	unsigned i = 0, l3cat_id_count = 0;
+	unsigned *cores = NULL;
+
+	ASSERT(cpu != NULL);
+	ASSERT(count != NULL);
+
+	if (cpu == NULL || count == NULL)
+		return NULL;
+
+	cores = (unsigned *) malloc(cpu->num_cores * sizeof(cores[0]));
+	if (cores == NULL)
+		return NULL;
+
+	for (i = 0; i < cpu->num_cores; i++)
+		if (cpu->cores[i].l3cat_id == l3cat_id)
+			cores[l3cat_id_count++] = cpu->cores[i].lcore;
+
+	if (!l3cat_id_count) {
+		free(cores);
+		return NULL;
+	}
+
+	*count = l3cat_id_count;
+	return cores;
+}
+
 const struct pqos_coreinfo *
 pqos_cpu_get_core_info(const struct pqos_cpuinfo *cpu, unsigned lcore)
 {

--- a/pqos/alloc.h
+++ b/pqos/alloc.h
@@ -67,8 +67,6 @@ void selfn_allocation_assoc(const char *arg);
  * @param [in] cap_l3ca L3 CAT capability structures
  * @param [in] cap_l2ca L2 CAT capability structures
  * @param [in] cap_mba MBA capability structures
- * @param [in] sock_count number of detected CPU sockets
- * @param [in] sockets arrays with detected CPU socket id's
  * @param [in] cpu_info cpu information structure
  * @param [in] verbose verbose mode flag
  */
@@ -76,8 +74,6 @@ void alloc_print_config(const struct pqos_capability *cap_mon,
                         const struct pqos_capability *cap_l3ca,
                         const struct pqos_capability *cap_l2ca,
                         const struct pqos_capability *cap_mba,
-                        const unsigned sock_count,
-                        const unsigned *sockets,
                         const struct pqos_cpuinfo *cpu_info,
                         const int verbose);
 

--- a/pqos/main.c
+++ b/pqos/main.c
@@ -982,8 +982,7 @@ int main(int argc, char **argv)
                  * Show info about allocation config and exit
                  */
                 alloc_print_config(cap_mon, cap_l3ca, cap_l2ca, cap_mba,
-                                   l3cat_id_count, l3cat_ids, p_cpu,
-                                   sel_verbose_mode);
+                                   p_cpu, sel_verbose_mode);
                 goto allocation_exit;
         }
 

--- a/rdtset/rdt.c
+++ b/rdtset/rdt.c
@@ -1346,7 +1346,7 @@ cfg_configure_cos(const struct pqos_l2ca *l2ca, const struct pqos_l3ca *l3ca,
 	const struct pqos_coreinfo *ci = NULL;
 	int ret;
 
-	if (NULL == l2ca || NULL == l3ca || NULL == mba)
+	if (NULL == l2ca && NULL == l3ca && NULL == mba)
 		return -EINVAL;
 
 	if (NULL == m_cap_l2ca && NULL == m_cap_l3ca && NULL == m_cap_mba)
@@ -1366,7 +1366,8 @@ cfg_configure_cos(const struct pqos_l2ca *l2ca, const struct pqos_l3ca *l3ca,
 		return ret;
 
 	/* Configure COS */
-	if (m_cap_l3ca != NULL && m_cap_l3ca->u.l3ca->num_classes > cos_id) {
+	if (l3ca != NULL && m_cap_l3ca != NULL &&
+	    m_cap_l3ca->u.l3ca->num_classes > cos_id) {
 		const unsigned l3cat_id = ci->l3cat_id;
 		struct pqos_l3ca ca = *l3ca;
 
@@ -1386,7 +1387,8 @@ cfg_configure_cos(const struct pqos_l2ca *l2ca, const struct pqos_l3ca *l3ca,
 		}
 	}
 
-	if (m_cap_l2ca != NULL  && m_cap_l2ca->u.l2ca->num_classes > cos_id) {
+	if (l2ca != NULL && m_cap_l2ca != NULL  &&
+	    m_cap_l2ca->u.l2ca->num_classes > cos_id) {
 		const unsigned l2_id = ci->l2_id;
 		struct pqos_l2ca ca = *l2ca;
 
@@ -1405,7 +1407,8 @@ cfg_configure_cos(const struct pqos_l2ca *l2ca, const struct pqos_l3ca *l3ca,
 		}
 	}
 
-	if (m_cap_mba != NULL && m_cap_mba->u.mba->num_classes > cos_id) {
+	if (mba != NULL && m_cap_mba != NULL &&
+	    m_cap_mba->u.mba->num_classes > cos_id) {
 		const unsigned mba_id = ci->mba_id;
 		struct pqos_mba mba_requested = *mba;
 		struct pqos_mba mba_actual;

--- a/rdtset/rdt.c
+++ b/rdtset/rdt.c
@@ -1468,46 +1468,126 @@ cfg_set_cores_os(const unsigned technology, const cpu_set_t *cores,
         if (core_num == 0)
                 return -EFAULT;
 
-        /* Assign all cores to single COS */
-        ret = pqos_alloc_assign(technology, core_array, core_num, &cos_id);
-        switch (ret) {
-        case PQOS_RETVAL_OK:
-                break;
-        case PQOS_RETVAL_RESOURCE:
-                fprintf(stderr, "No free COS available!\n");
-                return -EBUSY;
-        default:
-                fprintf(stderr, "Unable to assign COS!\n");
-                return -EFAULT;
-        }
+	if (technology & (1 << PQOS_CAP_TYPE_L2CA)) {
+		const unsigned l2_technology = 1 << PQOS_CAP_TYPE_L2CA;
+		/* Assign all cores to single COS */
+		ret = pqos_alloc_assign(l2_technology, core_array, core_num,
+					&cos_id);
+		switch (ret) {
+		case PQOS_RETVAL_OK:
+			break;
+		case PQOS_RETVAL_RESOURCE:
+			fprintf(stderr, "No free COS available!\n");
+			return -EBUSY;
+		default:
+			fprintf(stderr, "Unable to assign COS!\n");
+			return -EFAULT;
+		}
 
-        ret = get_max_res_id(technology, &max_id);
-        if (ret != 0)
-                return ret;
+		ret = get_max_res_id(l2_technology, &max_id);
+		if (ret != 0)
+			return ret;
 
-        /* Set COS definition on necessary sockets/clusters */
-        for (i = 0; i <= max_id; i++) {
-                memset(core_array, 0, sizeof(core_array));
+		/* Set COS definition on necessary sockets/clusters */
+		for (i = 0; i <= max_id; i++) {
+			memset(core_array, 0, sizeof(core_array));
 
-                /* Get cores on res id i */
-                if (technology & (1 << PQOS_CAP_TYPE_L2CA))
-                        ret = get_l2id_cores(cores, i, &core_num, core_array);
-		else if (technology & (1 << PQOS_CAP_TYPE_MBA))
-			ret = get_mba_id_cores(cores, i, &core_num, core_array);
-                else
+			/* Get cores on res id i */
+			ret = get_l2id_cores(cores, i, &core_num, core_array);
+			if (ret != 0)
+				return ret;
+
+			if (core_num == 0)
+				continue;
+
+			/* Configure COS on res ID i */
+			ret = cfg_configure_cos(l2ca, NULL, NULL, core_array[0],
+						cos_id);
+			if (ret != 0)
+				return ret;
+		}
+	}
+
+	if (technology & (1 << PQOS_CAP_TYPE_L3CA)) {
+		const unsigned l3_technology = 1 << PQOS_CAP_TYPE_L3CA;
+		/* Assign all cores to single COS */
+		ret = pqos_alloc_assign(l3_technology, core_array, core_num,
+					&cos_id);
+		switch (ret) {
+		case PQOS_RETVAL_OK:
+			break;
+		case PQOS_RETVAL_RESOURCE:
+			fprintf(stderr, "No free COS available!\n");
+			return -EBUSY;
+		default:
+			fprintf(stderr, "Unable to assign COS!\n");
+			return -EFAULT;
+		}
+
+		ret = get_max_res_id(l3_technology, &max_id);
+		if (ret != 0)
+			return ret;
+
+		/* Set COS definition on necessary sockets/clusters */
+		for (i = 0; i <= max_id; i++) {
+			memset(core_array, 0, sizeof(core_array));
+
+			/* Get cores on res id i */
 			ret = get_l3cat_id_cores(cores, i, &core_num,
 						 core_array);
-                if (ret != 0)
-                        return ret;
+			if (ret != 0)
+				return ret;
 
-                if (core_num == 0)
-                        continue;
+			if (core_num == 0)
+				continue;
 
-                /* Configure COS on res ID i */
-                ret = cfg_configure_cos(l2ca, l3ca, mba, core_array[0], cos_id);
-                if (ret != 0)
-                        return ret;
-        }
+			/* Configure COS on res ID i */
+			ret = cfg_configure_cos(NULL, l3ca, NULL, core_array[0],
+						cos_id);
+			if (ret != 0)
+				return ret;
+		}
+	}
+
+	if (technology & (1 << PQOS_CAP_TYPE_MBA)) {
+		const unsigned mba_technology = 1 << PQOS_CAP_TYPE_MBA;
+		/* Assign all cores to single COS */
+		ret = pqos_alloc_assign(mba_technology, core_array, core_num,
+					&cos_id);
+		switch (ret) {
+		case PQOS_RETVAL_OK:
+			break;
+		case PQOS_RETVAL_RESOURCE:
+			fprintf(stderr, "No free COS available!\n");
+			return -EBUSY;
+		default:
+			fprintf(stderr, "Unable to assign COS!\n");
+			return -EFAULT;
+		}
+
+		ret = get_max_res_id(mba_technology, &max_id);
+		if (ret != 0)
+			return ret;
+
+		/* Set COS definition on necessary sockets/clusters */
+		for (i = 0; i <= max_id; i++) {
+			memset(core_array, 0, sizeof(core_array));
+
+			/* Get cores on res id i */
+			ret = get_mba_id_cores(cores, i, &core_num, core_array);
+			if (ret != 0)
+				return ret;
+
+			if (core_num == 0)
+				continue;
+
+			/* Configure COS on res ID i */
+			ret = cfg_configure_cos(NULL, NULL, mba, core_array[0],
+						cos_id);
+			if (ret != 0)
+				return ret;
+		}
+	}
 
         return 0;
 }

--- a/rdtset/rdt.c
+++ b/rdtset/rdt.c
@@ -1795,7 +1795,7 @@ cfg_set_pids(const unsigned technology, const struct pqos_l3ca *l3ca,
                                 break;
 
                         /* Configure COS on res L2 ID i */
-                        ret = cfg_configure_cos(l2ca, l3ca, mba, core, cos_id);
+			ret = cfg_configure_cos(l2ca, NULL, NULL, core, cos_id);
                         if (ret != 0)
                                 break;
                 }
@@ -1803,28 +1803,51 @@ cfg_set_pids(const unsigned technology, const struct pqos_l3ca *l3ca,
         }
 
         /* Set COS definitions across all res L3 IDs */
-        if (technology & (1 << PQOS_CAP_TYPE_L3CA) ||
-            technology & (1 << PQOS_CAP_TYPE_MBA)) {
-                unsigned num_ids, *ids;
+	if (technology & (1 << PQOS_CAP_TYPE_L3CA)) {
+		unsigned num_ids, *ids;
 
-                ids = pqos_cpu_get_sockets(m_cpu, &num_ids);
-                if (ids == NULL)
-                        return -EFAULT;
+		ids = pqos_cpu_get_l3cat_ids(m_cpu, &num_ids);
+		if (ids == NULL)
+			return -EFAULT;
 
-                for (i = 0; i < num_ids; i++) {
-                        unsigned core;
+		for (i = 0; i < num_ids; i++) {
+			unsigned core;
 
-                        ret = pqos_cpu_get_one_core(m_cpu, ids[i], &core);
-                        if (ret != 0)
-                                break;
+			ret = pqos_cpu_get_one_by_l3cat_id(m_cpu, ids[i],
+							   &core);
+			if (ret != 0)
+				break;
 
-                        /* Configure COS on res L3 ID i */
-                        ret = cfg_configure_cos(l2ca, l3ca, mba, core, cos_id);
-                        if (ret != 0)
-                                break;
-                }
-                free(ids);
-        }
+			/* Configure COS on res L3 ID i */
+			ret = cfg_configure_cos(NULL, l3ca, NULL, core, cos_id);
+			if (ret != 0)
+				break;
+		}
+		free(ids);
+	}
+
+	/* Set COS definitions across all res L3 IDs */
+	if (technology & (1 << PQOS_CAP_TYPE_MBA)) {
+		unsigned num_ids, *ids;
+
+		ids = pqos_cpu_get_mba_ids(m_cpu, &num_ids);
+		if (ids == NULL)
+			return -EFAULT;
+
+		for (i = 0; i < num_ids; i++) {
+			unsigned core;
+
+			ret = pqos_cpu_get_one_by_mba_id(m_cpu, ids[i], &core);
+			if (ret != 0)
+				break;
+
+			/* Configure COS on res L3 ID i */
+			ret = cfg_configure_cos(NULL, NULL, mba, core, cos_id);
+			if (ret != 0)
+				break;
+		}
+		free(ids);
+	}
 set_pids_exit:
         if (ret != 0)
                 (void) pqos_alloc_release_pid(p, num_pids);

--- a/rdtset/rdt.c
+++ b/rdtset/rdt.c
@@ -1327,7 +1327,7 @@ cfg_configure_cos(const struct pqos_l2ca *l2ca, const struct pqos_l3ca *l3ca,
 
 	/* Configure COS */
 	if (m_cap_l3ca != NULL && m_cap_l3ca->u.l3ca->num_classes > cos_id) {
-		const unsigned socket_id = ci->socket;
+		const unsigned l3cat_id = ci->l3cat_id;
 		struct pqos_l3ca ca = *l3ca;
 
 		/* if COS is not configured, set it to default */
@@ -1337,11 +1337,11 @@ cfg_configure_cos(const struct pqos_l2ca *l2ca, const struct pqos_l3ca *l3ca,
 		/* set proper COS id */
 		ca.class_id = cos_id;
 
-		ret = pqos_l3ca_set(socket_id, 1, &ca);
+		ret = pqos_l3ca_set(l3cat_id, 1, &ca);
 		if (ret != PQOS_RETVAL_OK) {
 			fprintf(stderr,
-				"Error setting L3 CAT COS#%u on socket %u!\n",
-				cos_id, socket_id);
+				"Error setting L3 CAT COS#%u on l3cat id %u!\n",
+				cos_id, l3cat_id);
 			return -EFAULT;
 		}
 	}
@@ -1366,7 +1366,7 @@ cfg_configure_cos(const struct pqos_l2ca *l2ca, const struct pqos_l3ca *l3ca,
 	}
 
 	if (m_cap_mba != NULL && m_cap_mba->u.mba->num_classes > cos_id) {
-		const unsigned socket_id = ci->socket;
+		const unsigned mba_id = ci->mba_id;
 		struct pqos_mba mba_requested = *mba;
 		struct pqos_mba mba_actual;
 
@@ -1381,11 +1381,11 @@ cfg_configure_cos(const struct pqos_l2ca *l2ca, const struct pqos_l3ca *l3ca,
 		/* set proper COS id */
 		mba_requested.class_id = cos_id;
 
-		ret = pqos_mba_set(socket_id, 1, &mba_requested, &mba_actual);
+		ret = pqos_mba_set(mba_id, 1, &mba_requested, &mba_actual);
 		if (ret != PQOS_RETVAL_OK) {
 			fprintf(stderr,
-				"Error setting MBA COS#%u on socket %u!\n",
-				cos_id, socket_id);
+				"Error setting MBA COS#%u on mba id %u!\n",
+				cos_id, mba_id);
 			return -EFAULT;
 		}
 	}

--- a/rdtset/rdt.c
+++ b/rdtset/rdt.c
@@ -1101,10 +1101,10 @@ alloc_validate(void)
 }
 
 /**
- * @brief Gets cores from \a cores set which belong to \a socket
+ * @brief Gets cores from \a cores set which belong to \a l3cat_id
  *
  * @param [in] cores set of cores
- * @param [in] socket_id socket to get cores from
+ * @param [in] l3cat_id to get cores from
  * @param [out] core_num number of cores in \a core_array
  * @param [out] core_array array of cores
  *
@@ -1113,7 +1113,7 @@ alloc_validate(void)
  * @retval negative on error (-errno)
  */
 static int
-get_socket_cores(const cpu_set_t *cores, const unsigned socket_id,
+get_l3cat_id_cores(const cpu_set_t *cores, const unsigned l3cat_id,
                  unsigned *core_num, unsigned core_array[CPU_SETSIZE])
 {
 	unsigned i;
@@ -1130,7 +1130,7 @@ get_socket_cores(const cpu_set_t *cores, const unsigned socket_id,
 	}
 
 	for (i = 0, *core_num = 0; i < m_cpu->num_cores; i++) {
-		if (m_cpu->cores[i].socket != socket_id ||
+		if (m_cpu->cores[i].l3cat_id != l3cat_id ||
                     0 == CPU_ISSET(m_cpu->cores[i].lcore, cores))
 			continue;
 
@@ -1450,7 +1450,8 @@ cfg_set_cores_os(const unsigned technology, const cpu_set_t *cores,
                 if (technology & (1 << PQOS_CAP_TYPE_L2CA))
                         ret = get_l2id_cores(cores, i, &core_num, core_array);
                 else
-                        ret = get_socket_cores(cores, i, &core_num, core_array);
+			ret = get_l3cat_id_cores(cores, i, &core_num,
+						 core_array);
                 if (ret != 0)
                         return ret;
 
@@ -1501,7 +1502,8 @@ cfg_set_cores_msr(const unsigned technology, const cpu_set_t *cores,
                 if (technology & (1 << PQOS_CAP_TYPE_L2CA))
                         ret = get_l2id_cores(cores, i, &core_num, core_array);
                 else
-                        ret = get_socket_cores(cores, i, &core_num, core_array);
+			ret = get_l3cat_id_cores(cores, i, &core_num,
+						 core_array);
                 if (ret != 0)
                         return ret;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This pull request contains the preparation to Support AMD processors in cmt-cat tool.
This second set of changes. This has only the common changes. Next pull request will introduce mostly AMD related implementation.
## Description
<!--- Describe your changes in detail -->
AMD is working on to support RDT feature(AMD calls it QoS feature) in next generation hardware. Right now the tool intel-cmt-cat does not support AMD. Majority of these features are similar in both the vendors. However, there are some differences in the way some of these features are implemented in each vendor. We needed to separate those functions and define the vendor specific versions of these functions. This pull request is a first attempt in that direction.

The specification for this AMD feature is available at
https://developer.amd.com/wp-content/resources/56375.pdf

## Affected parts
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] library
- [x ] pqos utility
- [x ] rdtset utility
- [ ] other: (please specify)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Idea here is to have a one tool to support both Intel and AMD. It becomes easy to maintain one tool for both the vendors. It also benefits the OS vendors.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

This pull request only has partial set of changes. These patches does not add AMD support yet. So, I have tested on Intel box to make sure it does not introduce any regressions.
Hardware configuration of the Intel system.

lscpu

Architecture: x86_64
CPU op-mode(s): 32-bit, 64-bit
Byte Order: Little Endian
Address sizes: 46 bits physical, 48 bits virtual
CPU(s): 32
On-line CPU(s) list: 0-31
Thread(s) per core: 2
Core(s) per socket: 16
Socket(s): 1
NUMA node(s): 1
Vendor ID: GenuineIntel
CPU family: 6
Model: 85
Model name: Intel(R) Xeon(R) Gold 5218 CPU @ 2.30GHz
Stepping: 7
CPU MHz: 1001.145
CPU max MHz: 3900.0000
CPU min MHz: 1000.0000
BogoMIPS: 4600.00
Virtualization: VT-x
L1d cache: 32K
L1i cache: 32K
L2 cache: 1024K
L3 cache: 22528K
NUMA node0 CPU(s): 0-31
Flags: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge
mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall
nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl
xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl
vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid dca sse4_1 sse4_2
x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm
abm 3dnowprefetch cpuid_fault epb cat_l3 cdp_l3 invpcid_single intel_ppin
ssbd mba ibrs ibpb stibp ibrs_enhanced tpr_shadow vnmi flexpriority ept
vpid ept_ad fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 erms invpcid rtm
cqm mpx rdt_a avx512f avx512dq rdseed adx smap clflushopt clwb intel_pt
avx512cd avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves cqm_llc
cqm_occup_llc cqm_mbm_total cqm_mbm_local dtherm ida arat pln pts pku
ospke avx512_vnni md_clear flush_l1d arch_capabilities

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

User interface for the tool has not changed. So old documentation still holds good. But we may need to update the doc once the AMD support is fully integrated.
