### PR TITLE
Amd v11

### DIFF
--- a/lib/allocation.c
+++ b/lib/allocation.c
@@ -1455,6 +1455,7 @@ hw_alloc_reset(const enum pqos_cdp_config l3_cdp_cfg,
         const struct pqos_cap_l3ca *l3_cap = NULL;
         const struct pqos_cap_l2ca *l2_cap = NULL;
         const struct pqos_cap_mba *mba_cap = NULL;
+        const struct pqos_vendor_config *vconfig;
         int ret = PQOS_RETVAL_OK;
         unsigned max_l3_cos = 0;
         unsigned max_l2_cos = 0;
@@ -1474,6 +1475,7 @@ hw_alloc_reset(const enum pqos_cdp_config l3_cdp_cfg,
                mba_cfg == PQOS_MBA_ANY);
 
         _pqos_cap_get(&cap, NULL);
+        _pqos_get_vendor_config(&vconfig);
 
         /* Get L3 CAT capabilities */
         (void) _pqos_cap_get_type(PQOS_CAP_TYPE_L3CA, &alloc_cap);
@@ -1635,7 +1637,7 @@ hw_alloc_reset(const enum pqos_cdp_config l3_cdp_cfg,
                         if (ret != PQOS_RETVAL_OK)
                                 goto pqos_alloc_reset_exit;
 
-                        ret = alloc_cos_reset(v_config.mba_msr_reg,
+                        ret = alloc_cos_reset(vconfig->mba_msr_reg,
                                               mba_cap->num_classes, core, 0);
                         if (ret != PQOS_RETVAL_OK)
                                 goto pqos_alloc_reset_exit;

--- a/lib/allocation.c
+++ b/lib/allocation.c
@@ -944,6 +944,78 @@ hw_mba_set(const unsigned mba_id,
 }
 
 int
+hw_mba_set_amd(const unsigned mba_id,
+               const unsigned num_cos,
+               const struct pqos_mba *requested,
+               struct pqos_mba *actual)
+{
+        int ret = PQOS_RETVAL_OK;
+        unsigned i = 0, count = 0, core = 0;
+        const struct pqos_capability *mba_cap = NULL;
+
+        ASSERT(requested != NULL);
+        ASSERT(num_cos != 0);
+
+        /**
+         * Check if MBA is supported
+         */
+        ret = _pqos_cap_get_type(PQOS_CAP_TYPE_MBA, &mba_cap);
+        if (ret != PQOS_RETVAL_OK)
+                return PQOS_RETVAL_RESOURCE; /* MBA not supported */
+
+        count = mba_cap->u.mba->num_classes;
+
+        /**
+         * Check if class id's are within allowed range
+         * and if a controller is not requested.
+         */
+        for (i = 0; i < num_cos; i++) {
+                if (requested[i].class_id >= count) {
+                        LOG_ERROR("MBA COS%u is out of range (COS%u is max)!\n",
+                                  requested[i].class_id, count - 1);
+                        return PQOS_RETVAL_PARAM;
+                }
+
+                if (requested[i].ctrl != 0) {
+                        LOG_ERROR("MBA controller not supported!\n");
+                        return PQOS_RETVAL_PARAM;
+                }
+        }
+
+        ASSERT(m_cpu != NULL);
+        ret = pqos_cpu_get_one_by_mba_id(m_cpu, mba_id, &core);
+        if (ret != PQOS_RETVAL_OK)
+                return ret;
+
+        for (i = 0; i < num_cos; i++) {
+                const uint32_t reg =
+                    requested[i].class_id + PQOS_MSR_MBA_MASK_START_AMD;
+                uint64_t val = requested[i].mb_max;
+                int retval = MACHINE_RETVAL_OK;
+
+                retval = msr_write(core, reg, val);
+                if (retval != MACHINE_RETVAL_OK)
+                        return PQOS_RETVAL_ERROR;
+
+                /**
+                 * If table to store actual values set is passed,
+                 * read MSR values and store in table
+                 */
+                if (actual == NULL)
+                        continue;
+
+                retval = msr_read(core, reg, &val);
+                if (retval != MACHINE_RETVAL_OK)
+                        return PQOS_RETVAL_ERROR;
+
+                actual[i] = requested[i];
+                actual[i].mb_max = val;
+        }
+
+        return ret;
+}
+
+int
 hw_mba_get(const unsigned mba_id,
            const unsigned max_num_cos,
            unsigned *num_cos,

--- a/lib/allocation.c
+++ b/lib/allocation.c
@@ -1519,7 +1519,7 @@ hw_alloc_reset(const enum pqos_cdp_config l3_cdp_cfg,
                         if (ret != PQOS_RETVAL_OK)
                                 goto pqos_alloc_reset_exit;
 
-                        ret = alloc_cos_reset(PQOS_MSR_MBA_MASK_START,
+                        ret = alloc_cos_reset(v_config.mba_msr_reg,
                                               mba_cap->num_classes, core, 0);
                         if (ret != PQOS_RETVAL_OK)
                                 goto pqos_alloc_reset_exit;

--- a/lib/allocation.h
+++ b/lib/allocation.h
@@ -275,6 +275,24 @@ int hw_mba_get(const unsigned mba_id,
                unsigned *num_cos,
                struct pqos_mba *mba_tab);
 
+/**
+ * @brief Hardware interface to read MBA from \a mba_id
+ * @NOTE: This function is specific to AMD
+ *
+ * @param [in]  mba_id MBA resource id
+ * @param [in]  max_num_cos maximum number of classes of service
+ *              that can be accommodated at \a mba_tab
+ * @param [out] num_cos number of classes of service read into \a mba_tab
+ * @param [out] mba_tab table with read classes of service
+ *
+ * @return Operations status
+ * @retval PQOS_RETVAL_OK on success
+ */
+int hw_mba_get_amd(const unsigned mba_id,
+                   const unsigned max_num_cos,
+                   unsigned *num_cos,
+                   struct pqos_mba *mba_tab);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/allocation.h
+++ b/lib/allocation.h
@@ -259,6 +259,24 @@ int hw_mba_set(const unsigned mba_id,
                struct pqos_mba *actual);
 
 /**
+ * @brief Hardware interface to set classes of service
+ *        defined by \a requested on \a mba_id
+ * @NOTE: This function is specific to AMD
+ *
+ * @param [in]  MBA id
+ * @param [in]  num_cos number of classes of service at \a ca
+ * @param [in]  requested table with class of service definitions
+ * @param [out] actual table with class of service definitions
+ *
+ * @return Operations status
+ * @retval PQOS_RETVAL_OK on success
+ */
+int hw_mba_set_amd(const unsigned mba_id,
+                   const unsigned num_cos,
+                   const struct pqos_mba *requested,
+                   struct pqos_mba *actual);
+
+/**
  * @brief Hardware interface to read MBA from \a mba_id
  *
  * @param [in]  mba_id MBA resource id

--- a/lib/allocation.h
+++ b/lib/allocation.h
@@ -263,7 +263,7 @@ int hw_mba_set(const unsigned mba_id,
  *        defined by \a requested on \a mba_id
  * @NOTE: This function is specific to AMD
  *
- * @param [in]  MBA id
+ * @param [in]  mba_id
  * @param [in]  num_cos number of classes of service at \a ca
  * @param [in]  requested table with class of service definitions
  * @param [out] actual table with class of service definitions

--- a/lib/api.c
+++ b/lib/api.c
@@ -745,8 +745,11 @@ pqos_mba_set(const unsigned mba_id,
              const struct pqos_mba *requested,
              struct pqos_mba *actual)
 {
+        const struct pqos_vendor_config *vconfig;
         int ret;
         unsigned i;
+
+        _pqos_get_vendor_config(&vconfig);
 
         if (requested == NULL || num_cos == 0)
                 return PQOS_RETVAL_PARAM;
@@ -757,9 +760,9 @@ pqos_mba_set(const unsigned mba_id,
         for (i = 0; i < num_cos; i++)
                 if (requested[i].ctrl == 0 &&
                     (requested[i].mb_max == 0 ||
-                     requested[i].mb_max > v_config.mba_max)) {
+                     requested[i].mb_max > vconfig->mba_max)) {
                         LOG_ERROR("MBA COS%u rate out of range (from 1-%d)!\n",
-                                  requested[i].class_id, v_config.mba_max);
+                                  requested[i].class_id, vconfig->mba_max);
                         return PQOS_RETVAL_PARAM;
                 }
 
@@ -771,7 +774,7 @@ pqos_mba_set(const unsigned mba_id,
                 return ret;
         }
 
-        ret = v_config.mba_set(mba_id, num_cos, requested, actual);
+        ret = vconfig->mba_set(mba_id, num_cos, requested, actual);
 
         _pqos_api_unlock();
 
@@ -785,7 +788,10 @@ pqos_mba_get(const unsigned mba_id,
              unsigned *num_cos,
              struct pqos_mba *mba_tab)
 {
+        const struct pqos_vendor_config *vconfig;
         int ret;
+
+        _pqos_get_vendor_config(&vconfig);
 
         if (num_cos == NULL || mba_tab == NULL || max_num_cos == 0)
                 return PQOS_RETVAL_PARAM;
@@ -798,7 +804,7 @@ pqos_mba_get(const unsigned mba_id,
                 return ret;
         }
 
-        ret = v_config.mba_get(mba_id, max_num_cos, num_cos, mba_tab);
+        ret = vconfig->mba_get(mba_id, max_num_cos, num_cos, mba_tab);
 
         _pqos_api_unlock();
 

--- a/lib/api.c
+++ b/lib/api.c
@@ -772,10 +772,10 @@ pqos_mba_set(const unsigned mba_id,
         }
 
         if (m_interface == PQOS_INTER_MSR)
-                ret = hw_mba_set(mba_id, num_cos, requested, actual);
+                ret = v_config.hw_mba_set(mba_id, num_cos, requested, actual);
         else {
 #ifdef __linux__
-                ret = os_mba_set(mba_id, num_cos, requested, actual);
+                ret = v_config.os_mba_set(mba_id, num_cos, requested, actual);
 #else
                 LOG_INFO("OS interface not supported!\n");
                 ret = PQOS_RETVAL_RESOURCE;
@@ -808,10 +808,12 @@ pqos_mba_get(const unsigned mba_id,
         }
 
         if (m_interface == PQOS_INTER_MSR)
-                ret = hw_mba_get(mba_id, max_num_cos, num_cos, mba_tab);
+                ret =
+                    v_config.hw_mba_get(mba_id, max_num_cos, num_cos, mba_tab);
         else {
 #ifdef __linux__
-                ret = os_mba_get(mba_id, max_num_cos, num_cos, mba_tab);
+                ret =
+                    v_config.os_mba_get(mba_id, max_num_cos, num_cos, mba_tab);
 #else
                 LOG_INFO("OS interface not supported!\n");
                 ret = PQOS_RETVAL_RESOURCE;

--- a/lib/api.c
+++ b/lib/api.c
@@ -771,16 +771,7 @@ pqos_mba_set(const unsigned mba_id,
                 return ret;
         }
 
-        if (m_interface == PQOS_INTER_MSR)
-                ret = v_config.hw_mba_set(mba_id, num_cos, requested, actual);
-        else {
-#ifdef __linux__
-                ret = v_config.os_mba_set(mba_id, num_cos, requested, actual);
-#else
-                LOG_INFO("OS interface not supported!\n");
-                ret = PQOS_RETVAL_RESOURCE;
-#endif
-        }
+        ret = v_config.mba_set(mba_id, num_cos, requested, actual);
 
         _pqos_api_unlock();
 
@@ -807,18 +798,7 @@ pqos_mba_get(const unsigned mba_id,
                 return ret;
         }
 
-        if (m_interface == PQOS_INTER_MSR)
-                ret =
-                    v_config.hw_mba_get(mba_id, max_num_cos, num_cos, mba_tab);
-        else {
-#ifdef __linux__
-                ret =
-                    v_config.os_mba_get(mba_id, max_num_cos, num_cos, mba_tab);
-#else
-                LOG_INFO("OS interface not supported!\n");
-                ret = PQOS_RETVAL_RESOURCE;
-#endif
-        }
+        ret = v_config.mba_get(mba_id, max_num_cos, num_cos, mba_tab);
 
         _pqos_api_unlock();
 

--- a/lib/api.c
+++ b/lib/api.c
@@ -757,9 +757,9 @@ pqos_mba_set(const unsigned mba_id,
         for (i = 0; i < num_cos; i++)
                 if (requested[i].ctrl == 0 &&
                     (requested[i].mb_max == 0 ||
-                     requested[i].mb_max > PQOS_MBA_LINEAR_MAX)) {
+                     requested[i].mb_max > v_config.mba_max)) {
                         LOG_ERROR("MBA COS%u rate out of range (from 1-%d)!\n",
-                                   requested[i].class_id, PQOS_MBA_LINEAR_MAX);
+                                  requested[i].class_id, v_config.mba_max);
                         return PQOS_RETVAL_PARAM;
                 }
 

--- a/lib/cap.c
+++ b/lib/cap.c
@@ -76,6 +76,8 @@
 #include "resctrl.h"
 #include "perf_monitoring.h"
 
+struct pqos_vendor_config v_config;
+
 /**
  * ---------------------------------------
  * Local macros
@@ -1321,6 +1323,16 @@ pqos_init(const struct pqos_config *config)
         if (ret != LOG_RETVAL_OK) {
                 fprintf(stderr, "log_init() error\n");
                 goto init_error;
+        }
+
+        /**
+         * Initialise vendor default values and function pointers
+         */
+        ret = init_functions(&v_config);
+        if (ret != 0) {
+                LOG_ERROR("init_pointers() error %d\n", ret);
+                ret = PQOS_RETVAL_ERROR;
+                goto log_init_error;
         }
 
         /**

--- a/lib/cap.c
+++ b/lib/cap.c
@@ -1208,7 +1208,7 @@ discover_capabilities(struct pqos_cap **p_cap,
          * Memory bandwidth allocation init
          */
         if (inter == PQOS_INTER_MSR) {
-                if (pqos_get_vendor() == PQOS_VENDOR_AMD)
+                if (cpu->vendor == PQOS_VENDOR_AMD)
                         ret = discover_alloc_mba_amd(&det_mba);
                 else
                         ret = discover_alloc_mba(&det_mba);

--- a/lib/cap.c
+++ b/lib/cap.c
@@ -1325,6 +1325,14 @@ pqos_init(const struct pqos_config *config)
                 goto init_error;
         }
 
+        /* Detect the vendor first */
+        ret = detect_vendor();
+        if (ret != 0) {
+                LOG_ERROR("detect_vendor() error %d\n", ret);
+                ret = PQOS_RETVAL_ERROR;
+                goto log_init_error;
+        }
+
         /**
          * Initialise vendor default values and function pointers
          */

--- a/lib/cap.c
+++ b/lib/cap.c
@@ -1402,7 +1402,7 @@ pqos_init(const struct pqos_config *config)
         /**
          * Initialise vendor default values and function pointers
          */
-        ret = init_functions(&v_config, vendor, config->interface);
+        ret = init_vendor_functions(&v_config, vendor, config->interface);
         if (ret != 0) {
                 LOG_ERROR("init_pointers() error %d\n", ret);
                 ret = PQOS_RETVAL_ERROR;
@@ -1733,6 +1733,15 @@ _pqos_cap_get(const struct pqos_cap **cap,
         if (cpu != NULL) {
                 ASSERT(m_cpu != NULL);
                 *cpu = m_cpu;
+        }
+}
+
+void
+_pqos_get_vendor_config(const struct pqos_vendor_config **vconfig)
+{
+        if (vconfig != NULL) {
+                ASSERT(v_config != NULL);
+                *vconfig = &v_config;
         }
 }
 

--- a/lib/cap.c
+++ b/lib/cap.c
@@ -76,7 +76,7 @@
 #include "resctrl.h"
 #include "perf_monitoring.h"
 
-struct pqos_vendor_config v_config;
+static struct pqos_vendor_config *v_config = NULL;
 
 /**
  * ---------------------------------------
@@ -1741,7 +1741,7 @@ _pqos_get_vendor_config(const struct pqos_vendor_config **vconfig)
 {
         if (vconfig != NULL) {
                 ASSERT(v_config != NULL);
-                *vconfig = &v_config;
+                *vconfig = v_config;
         }
 }
 

--- a/lib/cap.c
+++ b/lib/cap.c
@@ -1330,6 +1330,7 @@ pqos_init(const struct pqos_config *config)
         unsigned i = 0, max_core = 0;
         int cat_init = 0, mon_init = 0;
         char *environment = NULL;
+        enum pqos_vendor vendor;
 
         if (config == NULL)
                 return PQOS_RETVAL_PARAM;
@@ -1391,8 +1392,8 @@ pqos_init(const struct pqos_config *config)
         }
 
         /* Detect the vendor first */
-        ret = detect_vendor();
-        if (ret != 0) {
+        vendor = detect_vendor();
+        if (vendor == PQOS_VENDOR_UNKNOWN) {
                 LOG_ERROR("detect_vendor() error %d\n", ret);
                 ret = PQOS_RETVAL_ERROR;
                 goto log_init_error;
@@ -1401,7 +1402,7 @@ pqos_init(const struct pqos_config *config)
         /**
          * Initialise vendor default values and function pointers
          */
-        ret = init_functions(&v_config);
+        ret = init_functions(&v_config, vendor);
         if (ret != 0) {
                 LOG_ERROR("init_pointers() error %d\n", ret);
                 ret = PQOS_RETVAL_ERROR;
@@ -1412,7 +1413,7 @@ pqos_init(const struct pqos_config *config)
          * Topology not provided through config.
          * CPU discovery done through internal mechanism.
          */
-        ret = cpuinfo_init(&m_cpu);
+        ret = cpuinfo_init(&m_cpu, vendor);
         if (ret != 0 || m_cpu == NULL) {
                 LOG_ERROR("cpuinfo_init() error %d\n", ret);
                 ret = PQOS_RETVAL_ERROR;

--- a/lib/cap.c
+++ b/lib/cap.c
@@ -1035,6 +1035,67 @@ discover_alloc_mba(struct pqos_cap_mba **r_cap)
 }
 
 /**
+ * @brief Discovers MBA feature for AMD
+ *
+ * @param r_cap place to store MBA capabilities structure
+ *
+ * @return Operation status
+ * @retval PQOS_RETVAL_OK success
+ * @retval PQOS_RETVAL_RESOURCE if not supported
+ */
+static int
+discover_alloc_mba_amd(struct pqos_cap_mba **r_cap)
+{
+        struct cpuid_out res;
+        struct pqos_cap_mba *cap = NULL;
+        const unsigned sz = sizeof(*cap);
+        int ret = PQOS_RETVAL_OK;
+
+        cap = (struct pqos_cap_mba *)malloc(sz);
+        if (cap == NULL)
+                return PQOS_RETVAL_RESOURCE;
+
+        ASSERT(cap != NULL);
+
+        memset(cap, 0, sz);
+        cap->mem_size = sz;
+        cap->ctrl = -1;
+        cap->ctrl_on = 0;
+
+        /**
+         * Run CPUID.0x80000008.0 to check
+         * for MBA allocation capability (bit 6 of ebx)
+         */
+        lcpuid(0x80000008, 0x0, &res);
+        if (!(res.ebx & (1 << 6))) {
+                LOG_INFO("CPUID.0x80000008.0: MBA not supported\n");
+                free(cap);
+                return PQOS_RETVAL_RESOURCE;
+        }
+
+        /**
+         * We can go to CPUID.0x10.0 to obtain more info
+         */
+        lcpuid(0x80000020, 0x0, &res);
+        if (!(res.ebx & (1 << 1))) {
+                LOG_INFO("CPUID 0x10.0: MBA not supported!\n");
+                free(cap);
+                return PQOS_RETVAL_RESOURCE;
+        }
+
+        lcpuid(0x80000020, 1, &res);
+
+        cap->num_classes = (res.edx & 0xffff) + 1;
+
+        /* AMD does not support throttle_max and is_linear. Set it to 0 */
+        cap->throttle_max = 0;
+        cap->is_linear = 0;
+
+        (*r_cap) = cap;
+        return ret;
+}
+
+/**
  * @brief Runs detection of platform monitoring and allocation capabilities
  *
  * @param p_cap place to store allocated capabilities structure
@@ -1146,8 +1207,12 @@ discover_capabilities(struct pqos_cap **p_cap,
         /**
          * Memory bandwidth allocation init
          */
-        if (inter == PQOS_INTER_MSR)
-                ret = discover_alloc_mba(&det_mba);
+        if (inter == PQOS_INTER_MSR) {
+                if (pqos_get_vendor() == PQOS_VENDOR_AMD)
+                        ret = discover_alloc_mba_amd(&det_mba);
+                else
+                        ret = discover_alloc_mba(&det_mba);
+        }
 #ifdef __linux__
         else if (inter == PQOS_INTER_OS || inter == PQOS_INTER_OS_RESCTRL_MON)
                 ret = os_cap_mba_discover(&det_mba, cpu);

--- a/lib/cap.c
+++ b/lib/cap.c
@@ -1402,7 +1402,7 @@ pqos_init(const struct pqos_config *config)
         /**
          * Initialise vendor default values and function pointers
          */
-        ret = init_functions(&v_config, vendor);
+        ret = init_functions(&v_config, vendor, config->interface);
         if (ret != 0) {
                 LOG_ERROR("init_pointers() error %d\n", ret);
                 ret = PQOS_RETVAL_ERROR;

--- a/lib/cap.h
+++ b/lib/cap.h
@@ -109,6 +109,13 @@ void _pqos_cap_get(const struct pqos_cap **cap,
                    const struct pqos_cpuinfo **cpu);
 
 /**
+ * @brief Internal API to retrieve PQoS vendor specific data
+ *
+ * @param [out] cap location to store PQoS vendor specific information at
+ */
+void _pqos_get_vendor_config(const struct pqos_vendor_config **vconfig);
+
+/**
  * @brief Internal API to retrie \a type of capability
  *
  * @param [in] type capability type to look for

--- a/lib/cpu_registers.h
+++ b/lib/cpu_registers.h
@@ -107,6 +107,38 @@ extern "C" {
 #define PQOS_MSR_MON_EVTSEL_EVTID_MASK ((1ULL << 8) - 1ULL)
 
 /**
+ * PQoS vendor value and function pointers
+ * @param cpuid_cache_leaf	: Cache mask leaf
+ * @param default_mba		: default memory bandwidth
+ * @param mba_msr_reg		: MBA mask base register
+ * @param hw_mba_get		: Get MBA mask
+ * @param hw_mba_set		: Set MBA mask with MSR method
+ * @param os_mba_get		: Get MBA mask with OS method
+ * @param os_mba_set		: Set MBA mask with OS method
+ */
+struct pqos_vendor_config {
+        int cpuid_cache_leaf;
+        unsigned mba_max;
+        uint32_t mba_msr_reg;
+        int (*hw_mba_get)(const unsigned mba_id,
+                          const unsigned max_num_cos,
+                          unsigned *num_cos,
+                          struct pqos_mba *mba_tab);
+        int (*hw_mba_set)(const unsigned mba_id,
+                          const unsigned num_cos,
+                          const struct pqos_mba *requested,
+                          struct pqos_mba *actual);
+        int (*os_mba_get)(const unsigned mba_id,
+                          const unsigned max_num_cos,
+                          unsigned *num_cos,
+                          struct pqos_mba *mba_tab);
+        int (*os_mba_set)(const unsigned mba_id,
+                          const unsigned num_cos,
+                          const struct pqos_mba *requested,
+                          struct pqos_mba *actual);
+};
+
+/**
  * MSR's to read instructions retired, unhalted cycles,
  * LLC references and LLC misses.
  * These MSR's are needed to calculate IPC (instructions per clock) and

--- a/lib/cpu_registers.h
+++ b/lib/cpu_registers.h
@@ -122,42 +122,6 @@ extern struct pqos_vendor_config v_config;
 #define PQOS_MSR_MON_EVTSEL_EVTID_MASK ((1ULL << 8) - 1ULL)
 
 /**
- * PQoS vendor value and function pointers
- * @param cpuid_cache_leaf	: Cache mask leaf
- * @param default_mba		: default memory bandwidth
- * @param mba_msr_reg		: MBA mask base register
- * @param hw_mba_get		: Get MBA mask
- * @param hw_mba_set		: Set MBA mask with MSR method
- * @param os_mba_get		: Get MBA mask with OS method
- * @param os_mba_set		: Set MBA mask with OS method
- */
-struct pqos_vendor_config {
-        int cpuid_cache_leaf;
-        unsigned mba_max;
-        uint32_t mba_msr_reg;
-        int (*mba_get)(const unsigned mba_id,
-                       const unsigned max_num_cos,
-                       unsigned *num_cos,
-                       struct pqos_mba *mba_tab);
-        int (*mba_set)(const unsigned mba_id,
-                       const unsigned num_cos,
-                       const struct pqos_mba *requested,
-                       struct pqos_mba *actual);
-};
-
-/**
- * @brief initializes intel/amd vendor functions
- *
- * @param vendor configuration structures
- * @param vendor identification
- * @return Operation status
- * @retval Success returns 0
- */
-int init_functions(struct pqos_vendor_config *ptr,
-                   enum pqos_vendor vendor,
-                   int interface);
-
-/**
  * MSR's to read instructions retired, unhalted cycles,
  * LLC references and LLC misses.
  * These MSR's are needed to calculate IPC (instructions per clock) and

--- a/lib/cpu_registers.h
+++ b/lib/cpu_registers.h
@@ -135,22 +135,14 @@ struct pqos_vendor_config {
         int cpuid_cache_leaf;
         unsigned mba_max;
         uint32_t mba_msr_reg;
-        int (*hw_mba_get)(const unsigned mba_id,
-                          const unsigned max_num_cos,
-                          unsigned *num_cos,
-                          struct pqos_mba *mba_tab);
-        int (*hw_mba_set)(const unsigned mba_id,
-                          const unsigned num_cos,
-                          const struct pqos_mba *requested,
-                          struct pqos_mba *actual);
-        int (*os_mba_get)(const unsigned mba_id,
-                          const unsigned max_num_cos,
-                          unsigned *num_cos,
-                          struct pqos_mba *mba_tab);
-        int (*os_mba_set)(const unsigned mba_id,
-                          const unsigned num_cos,
-                          const struct pqos_mba *requested,
-                          struct pqos_mba *actual);
+        int (*mba_get)(const unsigned mba_id,
+                       const unsigned max_num_cos,
+                       unsigned *num_cos,
+                       struct pqos_mba *mba_tab);
+        int (*mba_set)(const unsigned mba_id,
+                       const unsigned num_cos,
+                       const struct pqos_mba *requested,
+                       struct pqos_mba *actual);
 };
 
 /**
@@ -161,7 +153,9 @@ struct pqos_vendor_config {
  * @return Operation status
  * @retval Success returns 0
  */
-int init_functions(struct pqos_vendor_config *ptr, enum pqos_vendor vendor);
+int init_functions(struct pqos_vendor_config *ptr,
+                   enum pqos_vendor vendor,
+                   int interface);
 
 /**
  * MSR's to read instructions retired, unhalted cycles,

--- a/lib/cpu_registers.h
+++ b/lib/cpu_registers.h
@@ -54,6 +54,11 @@ extern "C" {
 #define PQOS_MSR_ASSOC_QECOS_MASK  0xffffffff00000000ULL
 #define PQOS_MSR_ASSOC_RMID_MASK   ((1ULL << 10) - 1ULL)
 
+/*
+ * This is a global structure to store all the vendor defines
+ */
+extern struct pqos_vendor_config v_config;
+
 /**
  * Allocation class of service (COS) MSR registers
  */
@@ -137,6 +142,15 @@ struct pqos_vendor_config {
                           const struct pqos_mba *requested,
                           struct pqos_mba *actual);
 };
+
+/**
+ * @brief initializes intel/amd vendor functions
+ *
+ * @param vendor configuration structures
+ * @return Operation status
+ * @retval Success returns 0
+ */
+int init_functions(struct pqos_vendor_config *ptr);
 
 /**
  * MSR's to read instructions retired, unhalted cycles,

--- a/lib/cpu_registers.h
+++ b/lib/cpu_registers.h
@@ -70,6 +70,11 @@ extern struct pqos_vendor_config v_config;
 #define PQOS_MSR_L2CA_MASK_START 0xD10
 #define PQOS_MSR_MBA_MASK_START  0xD50
 
+/**
+ * MBA Allocation class of service (COS) MSR register for AMD
+ */
+#define PQOS_MSR_MBA_MASK_START_AMD 0xC0000200
+
 #define PQOS_MSR_L3_QOS_CFG          0xC81   /**< L3 CAT config register */
 #define PQOS_MSR_L3_QOS_CFG_CDP_EN   1ULL    /**< L3 CDP enable bit */
 
@@ -80,6 +85,11 @@ extern struct pqos_vendor_config v_config;
  * MBA linear max value
  */
 #define PQOS_MBA_LINEAR_MAX 100
+
+/**
+ * MBA max value for AMD
+ */
+#define PQOS_MBA_MAX_AMD 0x800
 
 /**
  * Available types of allocation resource ID's.

--- a/lib/cpu_registers.h
+++ b/lib/cpu_registers.h
@@ -54,11 +54,6 @@ extern "C" {
 #define PQOS_MSR_ASSOC_QECOS_MASK  0xffffffff00000000ULL
 #define PQOS_MSR_ASSOC_RMID_MASK   ((1ULL << 10) - 1ULL)
 
-/*
- * This is a global structure to store all the vendor defines
- */
-extern struct pqos_vendor_config v_config;
-
 /**
  * Allocation class of service (COS) MSR registers
  */

--- a/lib/cpu_registers.h
+++ b/lib/cpu_registers.h
@@ -157,10 +157,11 @@ struct pqos_vendor_config {
  * @brief initializes intel/amd vendor functions
  *
  * @param vendor configuration structures
+ * @param vendor identification
  * @return Operation status
  * @retval Success returns 0
  */
-int init_functions(struct pqos_vendor_config *ptr);
+int init_functions(struct pqos_vendor_config *ptr, enum pqos_vendor vendor);
 
 /**
  * MSR's to read instructions retired, unhalted cycles,

--- a/lib/cpuinfo.c
+++ b/lib/cpuinfo.c
@@ -512,7 +512,9 @@ detect_vendor(void)
  * Initialize pointers for the vendors
  */
 int
-init_functions(struct pqos_vendor_config *ptr, enum pqos_vendor vendor)
+init_functions(struct pqos_vendor_config *ptr,
+               enum pqos_vendor vendor,
+               int interface)
 {
         /**
          * Make sure to initialize all the pointers to avoid
@@ -522,21 +524,25 @@ init_functions(struct pqos_vendor_config *ptr, enum pqos_vendor vendor)
                 ptr->cpuid_cache_leaf = 4;
                 ptr->mba_max = PQOS_MBA_LINEAR_MAX;
                 ptr->mba_msr_reg = PQOS_MSR_MBA_MASK_START;
-                ptr->hw_mba_get = hw_mba_get;
-                ptr->hw_mba_set = hw_mba_set;
+                ptr->mba_get = hw_mba_get;
+                ptr->mba_set = hw_mba_set;
 #ifdef __linux__
-                ptr->os_mba_get = os_mba_get;
-                ptr->os_mba_set = os_mba_set;
+                if (interface == PQOS_INTER_OS) {
+                        ptr->mba_get = os_mba_get;
+                        ptr->mba_set = os_mba_set;
+                }
 #endif
         } else if (vendor == PQOS_VENDOR_AMD) {
                 ptr->cpuid_cache_leaf = 0x8000001D;
                 ptr->mba_max = PQOS_MBA_MAX_AMD;
                 ptr->mba_msr_reg = PQOS_MSR_MBA_MASK_START_AMD;
-                ptr->hw_mba_get = hw_mba_get_amd;
-                ptr->hw_mba_set = hw_mba_set_amd;
+                ptr->mba_get = hw_mba_get_amd;
+                ptr->mba_set = hw_mba_set_amd;
 #ifdef __linux__
-                ptr->os_mba_get = os_mba_get_amd;
-                ptr->os_mba_set = os_mba_set_amd;
+                if (interface == PQOS_INTER_OS) {
+                        ptr->mba_get = os_mba_get_amd;
+                        ptr->mba_set = os_mba_set_amd;
+                }
 #endif
         } else {
                 LOG_ERROR("init_pointers: init failed!");

--- a/lib/cpuinfo.c
+++ b/lib/cpuinfo.c
@@ -49,10 +49,15 @@
 #include <sched.h>       /* sched affinity */
 #endif
 
+#include "pqos.h"
+
+#include "cpu_registers.h"
 #include "log.h"
 #include "cpuinfo.h"
 #include "types.h"
 #include "machine.h"
+#include "os_allocation.h"
+#include "allocation.h"
 
 /**
  * This structure will be made externally available
@@ -475,6 +480,26 @@ cpuinfo_build_topo(void)
         }
 
         return l_cpu;
+}
+
+/**
+ * Initialize pointers for the vendors
+ */
+int
+init_functions(struct pqos_vendor_config *ptr)
+{
+
+        ptr->cpuid_cache_leaf = 4;
+        ptr->mba_max = PQOS_MBA_LINEAR_MAX;
+        ptr->mba_msr_reg = PQOS_MSR_MBA_MASK_START;
+        ptr->hw_mba_get = hw_mba_get;
+        ptr->hw_mba_set = hw_mba_set;
+#ifdef __linux__
+        ptr->os_mba_get = os_mba_get;
+        ptr->os_mba_set = os_mba_set;
+#endif
+
+        return 0;
 }
 
 /**

--- a/lib/cpuinfo.c
+++ b/lib/cpuinfo.c
@@ -512,9 +512,9 @@ detect_vendor(void)
  * Initialize pointers for the vendors
  */
 int
-init_functions(struct pqos_vendor_config *ptr,
-               enum pqos_vendor vendor,
-               int interface)
+init_vendor_functions(struct pqos_vendor_config *ptr,
+                      enum pqos_vendor vendor,
+                      int interface)
 {
         /**
          * Make sure to initialize all the pointers to avoid

--- a/lib/cpuinfo.c
+++ b/lib/cpuinfo.c
@@ -350,7 +350,7 @@ detect_apic_masks(struct apic_info *apic)
         if (detect_apic_core_masks(apic) != 0)
                 return -2;
 
-        if (detect_apic_cache_masks(apic, CPUID_LEAF_CACHE) != 0)
+        if (detect_apic_cache_masks(apic, v_config.cpuid_cache_leaf) != 0)
                 return -3;
 
         return 0;

--- a/lib/cpuinfo.c
+++ b/lib/cpuinfo.c
@@ -60,11 +60,6 @@
 #include "allocation.h"
 
 /**
- * This variable will hold the CPU vendor
- */
-enum pqos_vendor cpu_vendor = PQOS_VENDOR_UNKNOWN;
-
-/**
  * This structure will be made externally available
  * If not NULL then module is initialized.
  */

--- a/lib/cpuinfo.c
+++ b/lib/cpuinfo.c
@@ -60,6 +60,11 @@
 #include "allocation.h"
 
 /**
+ * This variable will hold the CPU vendor
+ */
+enum pqos_vendor cpu_vendor = PQOS_VENDOR_UNKNOWN;
+
+/**
  * This structure will be made externally available
  * If not NULL then module is initialized.
  */
@@ -480,6 +485,25 @@ cpuinfo_build_topo(void)
         }
 
         return l_cpu;
+}
+
+int
+detect_vendor(void)
+{
+        int ret = 0;
+        struct cpuid_out vendor;
+
+        lcpuid(0x0, 0x0, &vendor);
+        if (vendor.ebx == 0x756e6547 && vendor.edx == 0x49656e69 &&
+            vendor.ecx == 0x6c65746e) {
+                cpu_vendor = PQOS_VENDOR_INTEL;
+        } else if (vendor.ebx == 0x68747541 && vendor.edx == 0x69746E65 &&
+                   vendor.ecx == 0x444D4163) {
+                cpu_vendor = PQOS_VENDOR_AMD;
+        } else {
+                ret = -EFAULT;
+        }
+        return ret;
 }
 
 /**

--- a/lib/cpuinfo.h
+++ b/lib/cpuinfo.h
@@ -60,7 +60,7 @@ extern enum pqos_vendor cpu_vendor;
  * @retval 0 on success
  * @retval -EFAULT on error
  */
-int detect_vendor(void);
+enum pqos_vendor detect_vendor(void);
 
 /**
  * @brief Initializes CPU information module
@@ -75,7 +75,7 @@ int detect_vendor(void);
  * @retval -EPERM cpuinfo already initialized
  * @retval -EFAULT error building & discovering the topology
  */
-int cpuinfo_init(const struct pqos_cpuinfo **topology);
+int cpuinfo_init(const struct pqos_cpuinfo **topology, enum pqos_vendor vendor);
 
 /**
  * @brief Shuts down CPU information module

--- a/lib/cpuinfo.h
+++ b/lib/cpuinfo.h
@@ -47,6 +47,22 @@ extern "C" {
 #endif
 
 /**
+ * Extern variables to provide vendor information
+ */
+extern enum pqos_vendor cpu_vendor;
+
+/**
+ * @brief Detects and returns the CPU vendor
+ *
+ * Sets the vendor identification. See pqos_vendor definitions.
+ *
+ * @return operation status
+ * @retval 0 on success
+ * @retval -EFAULT on error
+ */
+int detect_vendor(void);
+
+/**
  * @brief Initializes CPU information module
  *
  * CPU topology detection method is OS dependent.

--- a/lib/cpuinfo.h
+++ b/lib/cpuinfo.h
@@ -58,6 +58,18 @@ extern "C" {
 enum pqos_vendor detect_vendor(void);
 
 /**
+ * @brief initializes intel/amd vendor functions
+ *
+ * @param vendor configuration structures
+ * @param vendor identification
+ * @return Operation status
+ * @retval Success returns 0
+ */
+int init_vendor_functions(struct pqos_vendor_config *ptr,
+                          enum pqos_vendor vendor,
+                          int interface);
+
+/**
  * @brief Initializes CPU information module
  *
  * CPU topology detection method is OS dependent.

--- a/lib/cpuinfo.h
+++ b/lib/cpuinfo.h
@@ -47,11 +47,6 @@ extern "C" {
 #endif
 
 /**
- * Extern variables to provide vendor information
- */
-extern enum pqos_vendor cpu_vendor;
-
-/**
  * @brief Detects and returns the CPU vendor
  *
  * Sets the vendor identification. See pqos_vendor definitions.

--- a/lib/cpuinfo.h
+++ b/lib/cpuinfo.h
@@ -65,7 +65,7 @@ enum pqos_vendor detect_vendor(void);
  * @return Operation status
  * @retval Success returns 0
  */
-int init_vendor_functions(struct pqos_vendor_config *ptr,
+int init_vendor_functions(struct pqos_vendor_config **vconfig,
                           enum pqos_vendor vendor,
                           int interface);
 

--- a/lib/os_allocation.c
+++ b/lib/os_allocation.c
@@ -1605,6 +1605,125 @@ os_mba_set(const unsigned mba_id,
 }
 
 int
+os_mba_set_amd(const unsigned mba_id,
+               const unsigned num_cos,
+               const struct pqos_mba *requested,
+               struct pqos_mba *actual)
+{
+        int ret;
+        unsigned i;
+        unsigned num_grps = 0;
+        const struct pqos_cap *cap;
+        const struct pqos_cpuinfo *cpu;
+        const struct pqos_capability *mba_cap = NULL;
+
+        ASSERT(requested != NULL);
+        ASSERT(num_cos != 0);
+
+        _pqos_cap_get(&cap, &cpu);
+
+        /**
+         * Check if MBA is supported
+         */
+        ret = pqos_cap_get_type(cap, PQOS_CAP_TYPE_MBA, &mba_cap);
+        if (ret != PQOS_RETVAL_OK)
+                return PQOS_RETVAL_RESOURCE; /* MBA not supported */
+
+        ret = resctrl_alloc_get_grps_num(cap, &num_grps);
+        if (ret != PQOS_RETVAL_OK)
+                return ret;
+
+        if (num_cos > num_grps)
+                return PQOS_RETVAL_PARAM;
+
+        /**
+         * Check if class id's are within allowed range.
+         */
+        for (i = 0; i < num_cos; i++)
+                if (requested[i].class_id >= num_grps) {
+                        LOG_ERROR("MBA COS%u is out of range (COS%u is max)!\n",
+                                  requested[i].class_id, num_grps - 1);
+                        return PQOS_RETVAL_PARAM;
+                }
+
+        ret = verify_mba_id(mba_id, cpu);
+        if (ret != PQOS_RETVAL_OK)
+                goto os_mba_set_exit;
+
+        ret = resctrl_lock_exclusive();
+        if (ret != PQOS_RETVAL_OK)
+                goto os_mba_set_exit;
+
+        for (i = 0; i < num_cos; i++) {
+                struct resctrl_schemata *schmt;
+
+                if (mba_cap->u.mba->ctrl_on == 0 && requested[i].ctrl) {
+                        LOG_ERROR("MBA controller requested but not "
+                                  "enabled!\n");
+                        ret = PQOS_RETVAL_PARAM;
+                        goto os_mba_set_unlock;
+                }
+
+                if (mba_cap->u.mba->ctrl_on == 1 && !requested[i].ctrl) {
+                        LOG_ERROR("Expected MBA controller but not "
+                                  "requested!\n");
+                        ret = PQOS_RETVAL_PARAM;
+                        goto os_mba_set_unlock;
+                }
+
+                schmt = resctrl_schemata_alloc(cap, cpu);
+                if (schmt == NULL)
+                        ret = PQOS_RETVAL_ERROR;
+
+                /* read schemata file */
+                if (ret == PQOS_RETVAL_OK)
+                        ret = resctrl_alloc_schemata_read(requested[i].class_id,
+                                                          schmt);
+
+                /* update and write schemata */
+                if (ret == PQOS_RETVAL_OK) {
+                        struct pqos_mba mba;
+
+                        mba = requested[i];
+
+                        if (mba.ctrl == 0)
+                                mba.mb_max = requested[i].mb_max;
+
+                        ret = resctrl_schemata_mba_set(schmt, mba_id, &mba);
+                }
+
+                /* write schemata */
+                if (ret == PQOS_RETVAL_OK)
+                        ret = resctrl_alloc_schemata_write(
+                            requested[i].class_id, schmt);
+
+                if (actual != NULL) {
+                        /* read actual schemata */
+                        if (ret == PQOS_RETVAL_OK)
+                                ret = resctrl_alloc_schemata_read(
+                                    requested[i].class_id, schmt);
+
+                        /* update actual schemata */
+                        if (ret == PQOS_RETVAL_OK) {
+                                ret = resctrl_schemata_mba_get(schmt, mba_id,
+                                                               &actual[i]);
+                                actual[i].class_id = requested[i].class_id;
+                        }
+                }
+                resctrl_schemata_free(schmt);
+
+                if (ret != PQOS_RETVAL_OK)
+                        goto os_mba_set_unlock;
+        }
+
+os_mba_set_unlock:
+        resctrl_lock_release();
+
+os_mba_set_exit:
+        return ret;
+}
+
+int
 os_mba_get(const unsigned mba_id,
            const unsigned max_num_cos,
            unsigned *num_cos,

--- a/lib/os_allocation.h
+++ b/lib/os_allocation.h
@@ -277,6 +277,24 @@ int os_mba_get(const unsigned mba_id,
                struct pqos_mba *mba_tab);
 
 /**
+ * @brief OS interface to read MBA from \a socket
+ * @NOTE: This function is specific to AMD
+ *
+ * @param [in]  MBA id
+ * @param [in]  max_num_cos maximum number of classes of service
+ *              that can be accommodated at \a mba_tab
+ * @param [out] num_cos number of classes of service read into \a mba_tab
+ * @param [out] mba_tab table with read classes of service
+ *
+ * @return Operations status
+ * @retval PQOS_RETVAL_OK on success
+ */
+int os_mba_get_amd(const unsigned mba_id,
+                   const unsigned max_num_cos,
+                   unsigned *num_cos,
+                   struct pqos_mba *mba_tab);
+
+/**
  * @brief OS interface to associate \a lcore
  *        with given class of service
  *

--- a/lib/os_allocation.h
+++ b/lib/os_allocation.h
@@ -260,6 +260,23 @@ int os_mba_set(const unsigned mba_id,
                struct pqos_mba *actual);
 
 /**
+ * @brief OS interface to set classes of service defined by \a MBA id
+ * @NOTE: This function is specific to AMD
+ *
+ * @param [in]  MBA id
+ * @param [in]  num_cos number of classes of service at \a ca
+ * @param [in]  requested table with class of service definitions
+ * @param [out] actual table with class of service definitions
+ *
+ * @return Operations status
+ * @retval PQOS_RETVAL_OK on success
+ */
+int os_mba_set_amd(const unsigned mba_id,
+                   const unsigned num_cos,
+                   const struct pqos_mba *requested,
+                   struct pqos_mba *actual);
+
+/**
  * @brief OS interface to read MBA from \a mba_id
  *
  * @param [in]  mba_id MBA resource id

--- a/lib/pqos.h
+++ b/lib/pqos.h
@@ -1267,11 +1267,12 @@ int pqos_mba_ctrl_enabled(const struct pqos_cap *cap,
 /**
  * @brief returns the CPU vendor identification
  *
+ * @param [in] cpu CPU information structure from \a pqos_cap_get
  * @retval 0 if vendor unknown
  * @return 1 if the vendor is Intel
  * @return 2 if the vendor is AMD
  */
-enum pqos_vendor pqos_get_vendor(void);
+enum pqos_vendor pqos_get_vendor(const struct pqos_cpuinfo *cpu);
 
 /**
  * @brief Retrieves a monitoring value from a group for a specific event.

--- a/lib/pqos.h
+++ b/lib/pqos.h
@@ -1253,6 +1253,26 @@ int pqos_mba_ctrl_enabled(const struct pqos_cap *cap,
                           int *ctrl_enabled);
 
 /**
+ * =======================================
+ * Vendor values
+ * =======================================
+ */
+enum pqos_vendor {
+        PQOS_VENDOR_UNKNOWN = 0, /**< UNKNOWN */
+        PQOS_VENDOR_INTEL = 1,   /**< INTEL */
+        PQOS_VENDOR_AMD = 2      /**< AMD */
+};
+
+/**
+ * @brief returns the CPU vendor identification
+ *
+ * @retval 0 if vendor unknown
+ * @return 1 if the vendor is Intel
+ * @return 2 if the vendor is AMD
+ */
+enum pqos_vendor pqos_get_vendor(void);
+
+/**
  * @brief Retrieves a monitoring value from a group for a specific event.
  * @param [out] value monitoring value
  * @param [in] event_id event being monitored

--- a/lib/pqos.h
+++ b/lib/pqos.h
@@ -354,12 +354,24 @@ struct pqos_cacheinfo {
 };
 
 /**
+ * =======================================
+ * Vendor values
+ * =======================================
+ */
+enum pqos_vendor {
+        PQOS_VENDOR_UNKNOWN = 0, /**< UNKNOWN */
+        PQOS_VENDOR_INTEL = 1,   /**< INTEL */
+        PQOS_VENDOR_AMD = 2      /**< AMD */
+};
+
+/**
  * CPU topology structure
  */
 struct pqos_cpuinfo {
         unsigned mem_size;        /**< byte size of the structure */
         struct pqos_cacheinfo l2; /**< L2 cache information */
         struct pqos_cacheinfo l3; /**< L3 cache information */
+        enum pqos_vendor vendor;  /**< vendor Intel/AMD */
         unsigned num_cores;       /**< number of cores in the system */
         struct pqos_coreinfo cores[0];
 };
@@ -1251,17 +1263,6 @@ int pqos_l2ca_cdp_enabled(const struct pqos_cap *cap,
 int pqos_mba_ctrl_enabled(const struct pqos_cap *cap,
                           int *ctrl_supported,
                           int *ctrl_enabled);
-
-/**
- * =======================================
- * Vendor values
- * =======================================
- */
-enum pqos_vendor {
-        PQOS_VENDOR_UNKNOWN = 0, /**< UNKNOWN */
-        PQOS_VENDOR_INTEL = 1,   /**< INTEL */
-        PQOS_VENDOR_AMD = 2      /**< AMD */
-};
 
 /**
  * @brief returns the CPU vendor identification

--- a/lib/pqos.h
+++ b/lib/pqos.h
@@ -940,6 +940,30 @@ int pqos_mba_get(const unsigned mba_id,
                  unsigned *num_cos,
                  struct pqos_mba *mba_tab);
 
+/**
+ * PQoS vendor value and function pointers
+ * @param cpuid_cache_leaf	: Cache mask leaf
+ * @param default_mba		: default memory bandwidth
+ * @param mba_msr_reg		: MBA mask base register
+ * @param hw_mba_get		: Get MBA mask
+ * @param hw_mba_set		: Set MBA mask with MSR method
+ * @param os_mba_get		: Get MBA mask with OS method
+ * @param os_mba_set		: Set MBA mask with OS method
+ */
+struct pqos_vendor_config {
+        int cpuid_cache_leaf;
+        unsigned mba_max;
+        uint32_t mba_msr_reg;
+        int (*mba_get)(const unsigned mba_id,
+                       const unsigned max_num_cos,
+                       unsigned *num_cos,
+                       struct pqos_mba *mba_tab);
+        int (*mba_set)(const unsigned mba_id,
+                       const unsigned num_cos,
+                       const struct pqos_mba *requested,
+                       struct pqos_mba *actual);
+};
+
 /*
  * =======================================
  * Utility API

--- a/lib/utils.c
+++ b/lib/utils.c
@@ -669,7 +669,7 @@ pqos_mba_ctrl_enabled(const struct pqos_cap *cap,
 }
 
 enum pqos_vendor
-pqos_get_vendor(void)
+pqos_get_vendor(const struct pqos_cpuinfo *m_cpu)
 {
-        return cpu_vendor;
+        return m_cpu->vendor;
 }

--- a/lib/utils.c
+++ b/lib/utils.c
@@ -47,6 +47,7 @@
 #include "pqos.h"
 #include "types.h"
 #include "utils.h"
+#include "cpuinfo.h"
 
 #define TOPO_OBJ_SOCKET     0
 #define TOPO_OBJ_L2_CLUSTER 2
@@ -665,4 +666,10 @@ pqos_mba_ctrl_enabled(const struct pqos_cap *cap,
                 *ctrl_enabled = mba_cap->u.mba->ctrl_on;
 
         return PQOS_RETVAL_OK;
+}
+
+enum pqos_vendor
+pqos_get_vendor(void)
+{
+        return cpu_vendor;
 }

--- a/pqos/alloc.c
+++ b/pqos/alloc.c
@@ -988,8 +988,11 @@ print_per_socket_config(const struct pqos_capability *cap_l3ca,
                                 unit = " MBps";
                                 available = "";
                         } else {
-                                unit = "%";
                                 available = " available";
+                                if (pqos_get_vendor() == PQOS_VENDOR_AMD)
+                                        unit = "";
+                                else
+                                        unit = "%";
                         }
 
                         ret = pqos_mba_get(sockets[i], mba->num_classes,

--- a/pqos/alloc.c
+++ b/pqos/alloc.c
@@ -943,11 +943,15 @@ print_l2ca_config(const struct pqos_l2ca *ca, const int is_error)
 static void
 print_per_socket_config(const struct pqos_capability *cap_l3ca,
                         const struct pqos_capability *cap_mba,
+                        const struct pqos_cpuinfo *cpu_info,
                         const unsigned sock_count,
                         const unsigned *sockets)
 {
         int ret;
         unsigned i;
+
+        if (cpu_info == NULL)
+                return;
 
         if (cap_l3ca == NULL && cap_mba == NULL)
                 return;
@@ -989,7 +993,7 @@ print_per_socket_config(const struct pqos_capability *cap_l3ca,
                                 available = "";
                         } else {
                                 available = " available";
-                                if (pqos_get_vendor() == PQOS_VENDOR_AMD)
+                                if (cpu_info->vendor == PQOS_VENDOR_AMD)
                                         unit = "";
                                 else
                                         unit = "%";
@@ -1073,7 +1077,8 @@ void alloc_print_config(const struct pqos_capability *cap_mon,
 		return;
 	}
 
-        print_per_socket_config(cap_l3ca, cap_mba, sock_count, sockets);
+        print_per_socket_config(cap_l3ca, cap_mba, cpu_info, sock_count,
+                                sockets);
 
         if (cap_l2ca != NULL) {
                 /* Print L2 CAT class definitions per L2 cluster */

--- a/rdtset/common.h
+++ b/rdtset/common.h
@@ -52,6 +52,11 @@ extern "C" {
  */
 #define RDT_MAX_MBA 100
 
+/**
+ * MBA max value for AMD.
+ */
+#define RDT_MAX_MBA_AMD 0x800
+
 #ifndef MIN
 /**
  * Macro to return the minimum of two numbers

--- a/rdtset/rdt.c
+++ b/rdtset/rdt.c
@@ -134,6 +134,8 @@ rdt_cfg_get_type_str(const struct rdt_cfg cfg)
 static int
 rdt_cfg_is_valid(const struct rdt_cfg cfg)
 {
+        enum pqos_vendor vendor = pqos_get_vendor();
+
         if (cfg.u.generic_ptr == NULL)
                 return 0;
 
@@ -161,7 +163,9 @@ rdt_cfg_is_valid(const struct rdt_cfg cfg)
         case PQOS_CAP_TYPE_MBA:
                 return cfg.u.mba != NULL && cfg.u.mba->mb_max > 0 &&
                        ((cfg.u.mba->ctrl == 0 &&
-                         cfg.u.mba->mb_max <= RDT_MAX_MBA) ||
+                         cfg.u.mba->mb_max <= ((vendor == PQOS_VENDOR_AMD)
+                                                   ? RDT_MAX_MBA_AMD
+                                                   : RDT_MAX_MBA)) ||
                         cfg.u.mba->ctrl == 1);
 
         default:
@@ -451,6 +455,7 @@ rdt_ca_str_to_cbm(const char *param, struct rdt_cfg ca)
 static int
 rdt_mba_str_to_rate(const char *param, struct rdt_cfg mba)
 {
+        enum pqos_vendor vendor = pqos_get_vendor();
         uint64_t rate;
         int ret;
 
@@ -459,7 +464,9 @@ rdt_mba_str_to_rate(const char *param, struct rdt_cfg mba)
                 return -EINVAL;
 
         ret = str_to_uint64(param, 10, &rate);
-        if (ret < 0 || rate == 0 || rate > RDT_MAX_MBA)
+        if (ret < 0 || rate == 0 ||
+            rate >
+                ((vendor == PQOS_VENDOR_AMD) ? RDT_MAX_MBA_AMD : RDT_MAX_MBA))
                 return -EINVAL;
 
         mba.u.mba->ctrl = 0;
@@ -1296,6 +1303,8 @@ alloc_get_default_cos(struct pqos_l2ca *l2_def,
                       struct pqos_l3ca *l3_def,
                       struct pqos_mba *mba_def)
 {
+        enum pqos_vendor vendor = pqos_get_vendor();
+
         if (l2_def == NULL && l3_def == NULL && mba_def == NULL)
                 return -EINVAL;
 
@@ -1336,7 +1345,9 @@ alloc_get_default_cos(struct pqos_l2ca *l2_def,
                         mba_def->ctrl = 1;
                         mba_def->mb_max = UINT32_MAX;
                 } else
-                        mba_def->mb_max = RDT_MAX_MBA;
+                        mba_def->mb_max = (vendor == PQOS_VENDOR_AMD)
+                                              ? RDT_MAX_MBA_AMD
+                                              : RDT_MAX_MBA;
         }
 
         return 0;
@@ -1363,6 +1374,7 @@ cfg_configure_cos(const struct pqos_l2ca *l2ca,
                   const unsigned core_id,
                   const unsigned cos_id)
 {
+        enum pqos_vendor vendor = pqos_get_vendor();
         struct pqos_l2ca l2_defs;
         struct pqos_l3ca l3_defs;
         struct pqos_mba mba_defs;
@@ -1439,7 +1451,9 @@ cfg_configure_cos(const struct pqos_l2ca *l2ca,
                 if (!rdt_cfg_is_valid(wrap_mba(&mba_requested)))
                         mba_requested = mba_defs;
                 else if (mba_sc_mode(&g_cfg)) {
-                        mba_requested.mb_max = RDT_MAX_MBA;
+                        mba_requested.mb_max = (vendor == PQOS_VENDOR_AMD)
+                                                   ? RDT_MAX_MBA_AMD
+                                                   : RDT_MAX_MBA;
                         mba_requested.ctrl = 0;
                 }
 

--- a/rdtset/rdtset.c
+++ b/rdtset/rdtset.c
@@ -602,6 +602,15 @@ main(int argc, char **argv)
 
         memset(&g_cfg, 0, sizeof(g_cfg));
 
+        /**
+         * parse_args needs vendor information to validate the user
+         * arguments. Move rdtset_init early so that pqos_cpuinfo
+         * structure is initialized before parsing
+         */
+        ret = rdtset_init();
+        if (ret < 0)
+                exit(EXIT_FAILURE);
+
         /* Parse cmd line args */
         ret = parse_args(argc, argv);
         if (ret != 0) {
@@ -630,10 +639,6 @@ main(int argc, char **argv)
                 print_cmd_line_rdt_config();
                 print_cmd_line_cpu_config();
         }
-
-        ret = rdtset_init();
-        if (ret < 0)
-                exit(EXIT_FAILURE);
 
         /* display library version */
         if (0 != g_cfg.show_version) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This pull request contains the changes to Support AMD processors in cmt-cat tool.
This is third set of changes. This has the changes related to AMD specific implementation.

## Description
<!--- Describe your changes in detail -->
AMD is working on to support RDT feature(AMD calls it QoS feature) in next generation hardware. Right now the tool intel-cmt-cat does not support AMD. Majority of these features are similar in both the vendors. However, there are some differences in the way some of these features are implemented in each vendor. We needed to separate those functions and define the vendor specific versions of these functions. This pull request is a first attempt in that direction.

The specification for this AMD feature is available at
https://developer.amd.com/wp-content/resources/56375.pdf

## Affected parts
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] library
- [X] pqos utility
- [X] rdtset utility
- [ ] other: (please specify)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Idea here is to have a one tool to support both Intel and AMD. There is lot of commonalities between two vendors the way feature is implemented with some differences. It becomes easy to maintain one tool for both the vendors.  It also benefits the OS vendors.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Tested both on Intel and AMD hardware. 
Tested on following Intel configuration.  This is to make sure. There are no regressions.

#lscpu
Architecture: x86_64
CPU op-mode(s): 32-bit, 64-bit
Byte Order: Little Endian
Address sizes: 46 bits physical, 48 bits virtual
CPU(s): 32
On-line CPU(s) list: 0-31
Thread(s) per core: 2
Core(s) per socket: 16
Socket(s): 1
NUMA node(s): 1
Vendor ID: GenuineIntel
CPU family: 6
Model: 85
Model name: Intel(R) Xeon(R) Gold 5218 CPU @ 2.30GHz
Stepping: 7
CPU MHz: 1001.145
CPU max MHz: 3900.0000
CPU min MHz: 1000.0000
BogoMIPS: 4600.00
Virtualization: VT-x
L1d cache: 32K
L1i cache: 32K
L2 cache: 1024K
L3 cache: 22528K
NUMA node0 CPU(s): 0-31
Flags: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge
mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall
nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl
xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl
vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid dca sse4_1 sse4_2
x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm
abm 3dnowprefetch cpuid_fault epb cat_l3 cdp_l3 invpcid_single intel_ppin
ssbd mba ibrs ibpb stibp ibrs_enhanced tpr_shadow vnmi flexpriority epCPU op-mode(s): 32-bit, 64-bit

AMD hardware configuration.
# lscpu 
Architecture:          x86_64
CPU op-mode(s):        32-bit, 64-bit
Byte Order:            Little Endian
CPU(s):                128
On-line CPU(s) list:   0-127
Thread(s) per core:    2
Core(s) per socket:    32
Socket(s):             2
NUMA node(s):          2
Vendor ID:             AuthenticAMD
CPU family:            23
Model:                 49
Model name:            AMD Eng Sample: 100-000000054-02_30/20_N
Stepping:              0
CPU MHz:               1937.868
CPU max MHz:           2000.0000
CPU min MHz:           1500.0000
BogoMIPS:              3992.62
Virtualization:        AMD-V
L1d cache:             32K
L1i cache:             32K
L2 cache:              512K
L3 cache:              16384K
NUMA node0 CPU(s):     0-31,64-95
NUMA node1 CPU(s):     32-63,96-127
Flags:                 fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl nonstop_tsc cpuid extd_apicid aperfmperf pni pclmulqdq monitor ssse3 fma cx16 sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand lahf_lm cmp_legacy svm extapic cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw ibs skinit wdt tce topoext perfctr_core perfctr_nb bpext perfctr_llc mwaitx cpb cat_l3 cdp_l3 hw_pstate sme ssbd mba sev ibrs ibpb stibp vmmcall fsgsbase bmi1 avx2 smep bmi2 cqm rdt_a rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 xsaves cqm_llc cqm_occup_llc cqm_mbm_total cqm_mbm_local clzero irperf xsaveerptr wbnoinvd arat npt lbrv svm_lock nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold avic v_vmsave_vmload vgif umip rdpid overflow_recov succor smca
[root@localhost ~]# 


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

User interface for the tool has not changed. So old documentation still holds good. But we may need to update the doc once the AMD support is fully integrated.