### PR TITLE
pqos: Fix incorrect LLC misses output

### DIFF
--- a/pqos/monitor.c
+++ b/pqos/monitor.c
@@ -2152,7 +2152,8 @@ print_text_row(FILE *fp,
                                      mon_data->event & PQOS_PERF_EVENT_IPC,
                                      sel_events_max & PQOS_PERF_EVENT_IPC);
 
-        offset += fillin_text_column(" %10uk", (unsigned) mon_data->values.ipc,
+        offset += fillin_text_column(" %10uk", (unsigned)
+                                     mon_data->values.llc_misses_delta/1000,
                                      data + offset,
                                      sz_data - offset,
                                      mon_data->event & PQOS_PERF_EVENT_LLC_MISS,

--- a/pqos/monitor.c
+++ b/pqos/monitor.c
@@ -2152,7 +2152,7 @@ print_text_row(FILE *fp,
                                      mon_data->event & PQOS_PERF_EVENT_IPC,
                                      sel_events_max & PQOS_PERF_EVENT_IPC);
 
-        offset += fillin_text_column(" %10uk", (unsigned)
+        offset += fillin_text_column(" %10.0fk", (double)
                                      mon_data->values.llc_misses_delta/1000,
                                      data + offset,
                                      sz_data - offset,
@@ -2255,7 +2255,7 @@ print_xml_row(FILE *fp,
                                     sel_events_max & PQOS_PERF_EVENT_IPC,
                                     "ipc");
 
-        offset += fillin_xml_column("%llu", (unsigned long long)
+        offset += fillin_xml_column("%.0f", (double)
                                     mon_data->values.llc_misses_delta,
                                     data + offset,
                                     sz_data - offset,
@@ -2374,7 +2374,7 @@ print_csv_row(FILE *fp, char *time,
                                     mon_data->event & PQOS_PERF_EVENT_IPC,
                                     sel_events_max & PQOS_PERF_EVENT_IPC);
 
-        offset += fillin_csv_column(",%llu", (unsigned long long)
+        offset += fillin_csv_column(",%.0f", (double)
                                     mon_data->values.llc_misses_delta,
                                     data + offset,
                                     sz_data - offset,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
pqos: Fix incorrect LLC misses output

Regression issue caused by 1da37998bf5c ("pqos: Added options to disable IPC and LLC misses monitoring").

Fix https://github.com/intel/intel-cmt-cat/issues/153

## Description
<!--- Describe your changes in detail -->
Fix two issues in LLC misses monitoring in pqos:
1. pqos: Fix a typo in LLC misses monitoring
2. pqos: Fix incorrect LLC misses output due to type casting

## Affected parts
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] library
- [x] pqos utility
- [ ] rdtset utility
- [ ] other: (please specify)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Regression issue caused by 1da37998bf5c ("pqos: Added options to disable IPC and LLC misses monitoring").

Fix https://github.com/intel/intel-cmt-cat/issues/153

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

```
$ pqos
$ pqos -o tmp.xml -u xml
$ pqos -o tmp.csv -u csv

Without the fix:

    CORE         IPC      MISSES     LLC[KB]   MBL[MB/s]   MBR[MB/s]
       0        0.69  333562573k       264.0         0.3         0.0
       1        0.27  333562573k        88.0         0.0         0.0
       2        0.26  333562573k       176.0         0.2         0.0
       3        0.09  333562573k         0.0         0.0         0.0
       4        0.10  333562573k         0.0         0.0         0.0
       5        0.27  333562573k         0.0         0.0         0.0
       6        2.15  333562573k         0.0         0.0         0.0
       7        0.42  333562573k         0.0         0.0         0.0
       8        0.54  333562573k         0.0         0.0         0.0
       9        0.09  333562573k        88.0         0.0         0.0
      10        0.15  333562573k       176.0         0.0         0.1
      11        0.11  333562573k         0.0         0.0         0.0
      12        0.13  333562573k         0.0         0.0         0.0
      13        0.17  333562573k         0.0         0.0         0.0
      14        0.17  333562573k         0.0         0.1         0.0
      15        0.19  333562573k        88.0         0.1         0.0
      16        0.08  333562573k         0.0         0.0         0.0

With the fix:

    CORE         IPC      MISSES     LLC[KB]   MBL[MB/s]   MBR[MB/s]
       0        0.91        390k       616.0         0.0         0.0
       1        0.22        157k         0.0         0.0         0.0
       2        0.55        156k        88.0         0.0         0.0
       3        0.12        104k        88.0         0.0         0.0
       4        0.11        344k         0.0         0.0         0.0
       5        0.27        177k         0.0         0.0         0.0
       6        1.71        404k         0.0         0.0         0.0
       7        0.59        532k        88.0         0.0         0.0
       8        0.72        327k         0.0         0.0         0.0
       9        0.14         89k        88.0         0.0         0.0
      10        0.33        168k         0.0         0.0         0.0
      11        0.13        140k        88.0         0.0         0.0
      12        0.18        134k         0.0         0.0         0.0
      13        0.33        146k       968.0         0.0         0.0
      14        0.12        132k       176.0         0.0         0.0
      15        0.31        162k      2376.0         0.0         0.0
      16        0.12        159k       176.0         0.0         0.0
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

