### PR TITLE
membw: Fix compilation error when avx512 is not supported by gcc

### DIFF
--- a/tools/membw/Makefile
+++ b/tools/membw/Makefile
@@ -50,7 +50,8 @@ else
 CFLAGS += -O3 -g -D_FORTIFY_SOURCE=2
 endif
 
-ifneq ($(CC),icc)
+GCC_AVX512 := $(shell echo `gcc -march=native -dM -E - < /dev/null | grep "AVX512F"`)
+ifneq ($(GCC_AVX512),)
 CFLAGS += -mavx512f
 endif
 

--- a/tools/membw/membw.c
+++ b/tools/membw/membw.c
@@ -75,6 +75,10 @@
 #define ALWAYS_INLINE static inline __attribute__((always_inline))
 #endif
 
+#define GCC_VERSION (__GNUC__ * 10000 \
+               + __GNUC_MINOR__ * 100 \
+               + __GNUC_PATCHLEVEL__)
+
 #define MAX_OPTARG_LEN 64
 
 #define MAX_MEM_BW 100 * 1000 /* 100GBps */
@@ -805,8 +809,15 @@ mem_execute(const unsigned bw, const enum cl_type type)
                         break;
 #ifdef __x86_64__
                 case CL_TYPE_WRITE_WB_AVX512:
+/* If gcc version >= 4.9 */
+#if GCC_VERSION >= 40900
                         cl_write_avx512(ptr, val);
                         break;
+#else
+                        printf("No GCC support for AVX512 instructions!\n");
+                        stop_loop = 1;
+                        return;
+#endif
 #endif
                 case CL_TYPE_WRITE_WB_CLWB:
                         cl_write_clwb(ptr, val);
@@ -822,8 +833,15 @@ mem_execute(const unsigned bw, const enum cl_type type)
                         break;
 #ifdef __x86_64__
                 case CL_TYPE_WRITE_NT512:
+/* If gcc version >= 4.9 */
+#if GCC_VERSION >= 40900
                         cl_write_nt512(ptr, val);
                         break;
+#else
+                        printf("No GCC support for AVX512 instructions!\n");
+                        stop_loop = 1;
+                        return;
+#endif
                 case CL_TYPE_WRITE_NTDQ:
                         cl_write_ntdq(ptr, val);
                         break;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The membw tool depends on AVX-512 foundation instructions, which are
supported in gcc version 4.9 or above. Building with older version gcc
leads to compilation failure.

Add CFLAGs -mavx512f in Makefile only when gcc supports avx512. In
addition, add gcc version check in avx512 related stores operations.

Signed-off-by: Xiaochen Shen <xiaochen.shen@intel.com>

## Description
<!--- Describe your changes in detail -->
Fix https://github.com/intel/intel-cmt-cat/issues/156

NOTE:

- Please don't merge the dependent commit https://github.com/intel/intel-cmt-cat/pull/157/commits/530969574cd68e4ae2dd4a89c02f6857b1c71326 which is addressed in https://github.com/intel/intel-cmt-cat/pull/155
- I will rebase the code when https://github.com/intel/intel-cmt-cat/pull/155 is merged.

## Affected parts
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] library
- [ ] pqos utility
- [ ] rdtset utility
- [x] other: (please specify) membw

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix https://github.com/intel/intel-cmt-cat/issues/156
This issue breaks the building of intel-cmt-cat if avx512 is not supported by gcc.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
**Test steps:**

Without the fix:
```
# make
…
cc: error: unrecognized command line option ‘-mavx512f’
make[1]: *** [membw.o] Error 1
make[1]: Leaving directory `/home/xiaochen/intel-cmt-cat/tools/membw'
make: *** [all] Error 2
```

With the fix:
```
Case 1: CPU doesn't support AVX-512 (Broadwell server, gcc 4.8.5):

# ./membw -c 0 -b 50000 --write-avx512
No CPU support for AVX512 instructions!

# ./membw -c 0 -b 50000 --nt-write-avx512
No CPU support for AVX512 instructions!

Case 2: CPU supports AVX-512 but gcc doesn't support AVX-512 (Skylake server, gcc 4.8.5):

# ./membw -c 0 -b 50000 --write-avx512
- THREAD logical core id: 0,  memory bandwidth [MB]: 50000, starting...
No GCC support for AVX512 instructions!

exiting…

# ./membw -c 0 -b 50000 --nt-write-avx512
- THREAD logical core id: 0,  memory bandwidth [MB]: 50000, starting...
No GCC support for AVX512 instructions!

exiting...

Case 3: Both CPU and gcc support AVX-512 (Ice Lake server, gcc 8.3.1):
# ./membw -c 0 -b 50000 --write-avx512
- THREAD logical core id: 0,  memory bandwidth [MB]: 50000, starting...

# ./membw -c 0 -b 50000 --nt-write-avx512
- THREAD logical core id: 0,  memory bandwidth [MB]: 50000, starting...
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
