### PR TITLE
lib: make const array mon_event static, makes object smaller

### DIFF
--- a/lib/monitoring.c
+++ b/lib/monitoring.c
@@ -145,7 +145,7 @@ pqos_mon_poll_events(struct pqos_mon_data *group)
         int ret = PQOS_RETVAL_OK;
 
         /** List of non virtual events */
-        const enum pqos_mon_event mon_event[] = {
+        static const enum pqos_mon_event mon_event[] = {
             PQOS_MON_EVENT_L3_OCCUP,
             PQOS_MON_EVENT_LMEM_BW,
             PQOS_MON_EVENT_TMEM_BW,


### PR DESCRIPTION
Don't populate the const array mon_event on the stack but instead it
static. Makes the object code smaller by 186 bytes.

   text	   data	    bss	    dec	    hex	filename
   1436	      0	      4	   1440	    5a0	./lib/monitoring.o

After:
   text	   data	    bss	    dec	    hex	filename
   1250	      0	      4	   1254	    4e6	./lib/monitoring.o

(gcc version 10.2.0)

Signed-off-by: Colin Ian King <colin.king@canonical.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Affected parts
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] library
- [ ] pqos utility
- [ ] rdtset utility
- [ ] other: (please specify)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
