### PR TITLE
docs: fix simple typo, statisctics -> statistics

### DIFF
--- a/pqos/monitor.c
+++ b/pqos/monitor.c
@@ -175,7 +175,7 @@ struct proc_stats {
         pid_t pid; /**< process pid */
         unsigned long ticks_delta; /**< current cpu_time - previous ticks */
         double cpu_avg_ratio; /**< cpu usage/running time ratio*/
-        int valid; /**< marks if statisctics are fully processed */
+        int valid; /**< marks if statistics are fully processed */
 };
 
 /**


### PR DESCRIPTION
There is a small typo in pqos/monitor.c.

Should read `statistics` rather than `statisctics`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md