### PR TITLE
Fix Double quote array expansions to avoid re-splitting elements.

### DIFF
--- a/pqos/pqos-msr
+++ b/pqos/pqos-msr
@@ -39,4 +39,4 @@
 # This will cause the library to read/write directly to MSR's.
 
 # Run pqos utility passing CL args
-pqos $@
+pqos "$@"

--- a/pqos/pqos-os
+++ b/pqos/pqos-os
@@ -39,4 +39,4 @@
 # This will cause the library to read/write to the resctrl filesystem.
 
 # Run pqos utility passing CL args
-pqos -I $@
+pqos -I "$@"


### PR DESCRIPTION

## Description

This is probably harmless as users will not be passing files to the
program, but in the interest of future proofing this or possible unseen
abuse, quoting it will solve a few of these issues for you.

This silences: https://github.com/koalaman/shellcheck/wiki/SC2068


## Affected parts

- [ ] library
- [x] pqos utility
- [ ] rdtset utility
- [ ] other: (please specify)

## Motivation and Context
I run shellchecks over the code on the system, its part of a mini audit that I am taking part of.


## How Has This Been Tested?
This has had basic testing, I ran the pqos command, it worked as before... I tried abusing shell expansion it failed as it did before.
Fedora 34 - x86-64 on A newer xeon CPU.
This only really affects the shell side of the users interaction.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Thank you for your time.  This is really minor and would understand if you dont want it.

Have a good day.