### PR TITLE
MBA fixes - AMD 

### DIFF
--- a/lib/os_allocation.c
+++ b/lib/os_allocation.c
@@ -51,6 +51,7 @@
 #include "resctrl_alloc.h"
 #include "resctrl_monitoring.h"
 #include "resctrl_utils.h"
+#include "cpuinfo.h"
 
 int
 os_alloc_mount(const enum pqos_cdp_config l3_cdp_cfg,
@@ -63,6 +64,7 @@ os_alloc_mount(const enum pqos_cdp_config l3_cdp_cfg,
         const struct pqos_capability *alloc_cap = NULL;
         const struct pqos_cap *cap;
         const struct pqos_cpuinfo *cpu;
+        const struct cpuinfo_config *vconfig;
         int ret;
 
         if (l3_cdp_cfg != PQOS_REQUIRE_CDP_ON &&
@@ -83,6 +85,7 @@ os_alloc_mount(const enum pqos_cdp_config l3_cdp_cfg,
         }
 
         _pqos_cap_get(&cap, &cpu);
+        cpuinfo_get_config(&vconfig);
 
         if (l3_cdp_cfg == PQOS_REQUIRE_CDP_OFF &&
             l2_cdp_cfg == PQOS_REQUIRE_CDP_OFF && mba_cfg == PQOS_MBA_DEFAULT)
@@ -149,7 +152,7 @@ mount:
                 }
 
                 ret = resctrl_schemata_mba_get(schmt, 0, &mba);
-                if (ret == PQOS_RETVAL_OK && mba.mb_max <= 100) {
+                if (ret == PQOS_RETVAL_OK && mba.mb_max <= vconfig->mba_max) {
                         LOG_ERROR("MBA CTRL not enabled\n");
                         ret = PQOS_RETVAL_ERROR;
                 }

--- a/lib/os_cap.c
+++ b/lib/os_cap.c
@@ -680,7 +680,7 @@ os_cap_get_mba_ctrl(const struct pqos_cap *cap,
                 if (ret == PQOS_RETVAL_OK) {
                         fd = resctrl_alloc_fopen(grp, "schemata", "w");
                         if (fd != NULL) {
-                                fprintf(fd, "MB:0=%d\n", vconfig->mba_max * 2);
+                                fprintf(fd, "MB:0=%u\n", vconfig->mba_max * 2);
                                 if (fclose(fd) == 0)
                                         *enabled = 1;
                                 else

--- a/pqos/alloc.c
+++ b/pqos/alloc.c
@@ -392,7 +392,7 @@ set_mba_cos(const unsigned class_id,
                 int ret = pqos_mba_set(sock_ids[i], 1, &mba, &actual);
 
                 if (cpu->vendor == PQOS_VENDOR_AMD) {
-                        package = "Core Complex ";
+                        package = "Core Complex";
                         unit = "";
                 } else {
                         package = "SOCKET ";

--- a/pqos/alloc.c
+++ b/pqos/alloc.c
@@ -233,7 +233,7 @@ set_l3_cos(const unsigned class_id,
                 if (cpu->vendor == PQOS_VENDOR_AMD)
                         package = "Core Complex";
                 else
-                        package = "SOCKET ";
+                        package = "SOCKET";
 
                 if (ret != PQOS_RETVAL_OK) {
                         printf("%s %u L3CA COS%u - FAILED!\n", package,

--- a/pqos/alloc.c
+++ b/pqos/alloc.c
@@ -169,9 +169,11 @@ set_l3_cos(const unsigned class_id,
            const uint64_t mask,
            const unsigned *sock_ids,
            const unsigned sock_num,
-           const unsigned scope)
+           const unsigned scope,
+           const struct pqos_cpuinfo *cpu)
 {
         unsigned i, set = 0;
+        const char *package;
 
         if (sock_ids == NULL || mask == 0) {
                 printf("Failed to set L3 CAT configuration!\n");
@@ -228,18 +230,23 @@ set_l3_cos(const unsigned class_id,
 
                 /* set new L3 class definition */
                 ret = pqos_l3ca_set(sock_ids[i], 1, &ca);
+                if (cpu->vendor == PQOS_VENDOR_AMD)
+                        package = "Core Complex ";
+                else
+                        package = "SOCKET ";
+
                 if (ret != PQOS_RETVAL_OK) {
-                        printf("SOCKET %u L3CA COS%u - FAILED!\n", sock_ids[i],
-                               ca.class_id);
+                        printf("%s %u L3CA COS%u - FAILED!\n", package,
+                               sock_ids[i], ca.class_id);
                         break;
                 }
                 if (ca.cdp)
-                        printf("SOCKET %u L3CA COS%u => DATA 0x%lx,CODE "
+                        printf("%s %u L3CA COS%u => DATA 0x%lx,CODE "
                                "0x%lx\n",
-                               sock_ids[i], ca.class_id, (long)ca.u.s.data_mask,
-                               (long)ca.u.s.code_mask);
+                               package, sock_ids[i], ca.class_id,
+                               (long)ca.u.s.data_mask, (long)ca.u.s.code_mask);
                 else
-                        printf("SOCKET %u L3CA COS%u => MASK 0x%lx\n",
+                        printf("%s %u L3CA COS%u => MASK 0x%lx\n", package,
                                sock_ids[i], ca.class_id, (long)ca.u.ways_mask);
                 set++;
         }
@@ -362,7 +369,8 @@ set_mba_cos(const unsigned class_id,
             const uint64_t available_bw,
             const unsigned *sock_ids,
             const unsigned sock_num,
-            int ctrl)
+            int ctrl,
+            const struct pqos_cpuinfo *cpu)
 {
         unsigned i, set = 0;
         struct pqos_mba mba, actual;
@@ -379,21 +387,32 @@ set_mba_cos(const unsigned class_id,
          * Set all selected classes
          */
         for (i = 0; i < sock_num; i++) {
+                const char *unit;
+                const char *package;
                 int ret = pqos_mba_set(sock_ids[i], 1, &mba, &actual);
 
+                if (cpu->vendor == PQOS_VENDOR_AMD) {
+                        package = "Core Complex ";
+                        unit = "";
+                } else {
+                        package = "SOCKET ";
+                        unit = "%";
+                }
+
                 if (ret != PQOS_RETVAL_OK) {
-                        printf("SOCKET %u MBA COS%u - FAILED!\n", sock_ids[i],
-                               mba.class_id);
+                        printf("%s %u MBA COS%u - FAILED!\n", package,
+                               sock_ids[i], mba.class_id);
                         break;
                 }
 
-                printf("SOCKET %u MBA COS%u => ", sock_ids[i], actual.class_id);
+                printf("%s %u MBA COS%u => ", package, sock_ids[i],
+                       actual.class_id);
 
                 if (ctrl == 1)
                         printf("%u MBps\n", mba.mb_max);
                 else
-                        printf("%u%% requested, %u%% applied\n", mba.mb_max,
-                               actual.mb_max);
+                        printf("%u%s requested, %u%s applied\n", mba.mb_max,
+                               unit, actual.mb_max, unit);
 
                 set++;
         }
@@ -452,7 +471,7 @@ set_allocation_cos(char *str,
                         printf("Failed to retrieve socket info!\n");
                         return -1;
                 }
-                ret = set_mba_cos(class_id, mask, ids, n, ctrl);
+                ret = set_mba_cos(class_id, mask, ids, n, ctrl, cpu);
                 if (res_ids == NULL && ids != NULL)
                         free(ids);
                 return ret;
@@ -478,7 +497,7 @@ set_allocation_cos(char *str,
                 printf("Failed to retrieve socket info!\n");
                 return -1;
         }
-        ret = set_l3_cos(class_id, mask, ids, n, update_scope);
+        ret = set_l3_cos(class_id, mask, ids, n, update_scope, cpu);
         if (res_ids == NULL && ids != NULL)
                 free(ids);
 

--- a/pqos/alloc.c
+++ b/pqos/alloc.c
@@ -231,7 +231,7 @@ set_l3_cos(const unsigned class_id,
                 /* set new L3 class definition */
                 ret = pqos_l3ca_set(sock_ids[i], 1, &ca);
                 if (cpu->vendor == PQOS_VENDOR_AMD)
-                        package = "Core Complex ";
+                        package = "Core Complex";
                 else
                         package = "SOCKET ";
 

--- a/pqos/alloc.c
+++ b/pqos/alloc.c
@@ -395,7 +395,7 @@ set_mba_cos(const unsigned class_id,
                         package = "Core Complex";
                         unit = "";
                 } else {
-                        package = "SOCKET ";
+                        package = "SOCKET";
                         unit = "%";
                 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Couple of fixes.
1. MBA feature was broken for AMD
2. Changed printing messages from SOCKET to Core Complex for AMD
 
## Description
<!--- Describe your changes in detail -->
The MBA feature was not working when trying to set the MBA limits on AMD.
....
# pqos -I OS -e mba:1=0xf
NOTE:  Mixed use of MSR and kernel interfaces to manage
       CAT or CMT & MBM may lead to unexpected behavior.
ERROR: Expected MBA controller but not requested!
SOCKET 0 MBA COS1 - FAILED!
Allocation configuration error!
```
The code was using the hard coded value to detect the feature. Changed it to use the vendor specific mba_max values while detecting the feature.

Also fixed printing  messages on AMD.
Before the change.
SOCKET 0 MBA COS1 => 256% requested, 256% applied
SOCKET 1 MBA COS1 => 256% requested, 256% applied
SOCKET 2 MBA COS1 => 256% requested, 256% applied
SOCKET 3 MBA COS1 => 256% requested, 256% applied

After the change.

Core Complex 0 MBA COS1 => 256 requested, 256 applied
Core Complex 1 MBA COS1 => 256 requested, 256 applied
Core Complex 2 MBA COS1 => 256 requested, 256 applied
Core Complex 3 MBA COS1 => 256 requested, 256 applied

## Affected parts
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] library
- [x] pqos utility
- [ ] rdtset utility
- [ ] other: (please specify)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Without this fix MBA feature wont work on AMD.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested on AMD system.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
