### PR TITLE
Fix pqos startup vs. clock stepping race condition

### DIFF
--- a/pqos/Makefile
+++ b/pqos/Makefile
@@ -110,12 +110,12 @@ install: $(APP) $(MAN)
 ifeq ($(shell uname), FreeBSD)
 	install -d $(BIN_DIR)
 	install -d $(MAN_DIR)
-	install -s $(APP) $(BIN_DIR)
+	install $(APP) $(BIN_DIR)
 	install $(APP)-msr $(BIN_DIR)
 	install -m 0444 $(MAN) $(MAN_DIR)
 	ln -f -s $(MAN) $(MAN_DIR)/$(APP)-msr.8
 else
-	install -D -s $(APP) $(BIN_DIR)/$(APP)
+	install -D $(APP) $(BIN_DIR)/$(APP)
 	install -D $(APP)-msr $(BIN_DIR)/$(APP)-msr
 	install -D $(APP)-os $(BIN_DIR)/$(APP)-os
 	install -m 0444 $(MAN) -D $(MAN_DIR)/$(MAN)

--- a/rdtset/Makefile
+++ b/rdtset/Makefile
@@ -117,10 +117,10 @@ install: $(APP) $(MAN)
 ifeq ($(shell uname), FreeBSD)
 	install -d $(BIN_DIR)
 	install -d $(MAN_DIR)
-	install -s $(APP) $(BIN_DIR)
+	install $(APP) $(BIN_DIR)
 	install -m 0444 $(MAN) $(MAN_DIR)
 else
-	install -D -s $(APP) $(BIN_DIR)/$(APP)
+	install -D $(APP) $(BIN_DIR)/$(APP)
 	install -m 0444 $(MAN) -D $(MAN_DIR)/$(MAN)
 endif
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

This change fixes #194 by replacing the custom nanosleep time computation with a timerfd file descriptor.

## Description

See https://github.com/intel/intel-cmt-cat/issues/194#issuecomment-978161482 for a detailed analysis.

## Affected parts
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] library
- [x] pqos utility
- [ ] rdtset utility
- [ ] other: (please specify)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Previously, I noticed pqos consuming 100% and calling syscalls at an ultra high rate, when started as part of a systemd service, during boot.

Obviously, such an issue is a show stopper for serious usage.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Tested it in the environment where I previously could reproduce the issue very reliably.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
