### PR TITLE
minor static analysis scan-build warning fixes

### DIFF
--- a/lib/hw_monitoring.c
+++ b/lib/hw_monitoring.c
@@ -215,7 +215,7 @@ rmid_get_event_max(const struct pqos_cap *cap,
                    pqos_rmid_t *rmid,
                    const enum pqos_mon_event event)
 {
-        pqos_rmid_t max_rmid = m_rmid_max;
+        pqos_rmid_t max_rmid;
         const struct pqos_capability *item = NULL;
         const struct pqos_cap_mon *mon = NULL;
         unsigned mask_found = 0;

--- a/pqos/monitor.c
+++ b/pqos/monitor.c
@@ -2209,8 +2209,7 @@ print_text_row(FILE *fp,
 
                 if (get_pid_cores(mon_data, core_list, sizeof(core_list)) ==
                     -1) {
-                        memset(core_list, 0, sizeof(core_list));
-                        strncat(core_list, "err", sizeof(core_list) - 1);
+                        strncpy(core_list, "err", sizeof(core_list) - 1);
                 }
 
                 fprintf(fp, "\n%8.8s %8.8s%s", (char *)mon_data->context,
@@ -2314,8 +2313,7 @@ print_xml_row(FILE *fp,
 
                 if (get_pid_cores(mon_data, core_list, sizeof(core_list)) ==
                     -1) {
-                        memset(core_list, 0, sizeof(core_list));
-                        strncat(core_list, "err", sizeof(core_list) - 1);
+                        strncpy(core_list, "err", sizeof(core_list) - 1);
                 }
 
                 fprintf(fp,
@@ -2410,8 +2408,7 @@ print_csv_row(FILE *fp,
 
                 if (get_pid_cores(mon_data, core_list, sizeof(core_list)) ==
                     -1) {
-                        memset(core_list, 0, sizeof(core_list));
-                        strncat(core_list, "err", sizeof(core_list) - 1);
+                        strncpy(core_list, "err", sizeof(core_list) - 1);
                 }
 
                 fprintf(fp, "%s,\"%s\",\"%s\"%s\n", time,


### PR DESCRIPTION


- [x] library
- [x] pqos utility
- [ ] rdtset utility
- [ ] other: (please specify)

Running static analysis with clang's scan-build found a couple of issues, one set related to incorrect use of strncpy that can be easily fixed with strncpy and another issue with a redundant initialization of a variable (minor code clean-up).  I generally run static analysis on code that I package for Debian to ensure it's as bug free as possible.

Tested on a Numa Intel camelback 12 core SDP box with ubuntu 22.04 - ran pqos.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
