### PR TITLE
spec: rpmbuild failed, fix the spec script

### DIFF
--- a/rpm/intel-cmt-cat.spec
+++ b/rpm/intel-cmt-cat.spec
@@ -38,7 +38,7 @@
 
 Summary:            Provides command line interface to CMT, MBM, CAT, CDP and MBA technologies
 Name:               %{githubname}
-Release:            1%{?dist}
+Release:            2%{?dist}
 Version:            %{githubver}
 License:            BSD
 Group:              Development/Tools
@@ -160,11 +160,11 @@ install -m 0644 %{_builddir}/%{githubfull}/examples/c/CMT_MBM/monitor_app.c %{bu
 %{_mandir}/man8/rdtset.8.gz
 %{_bindir}/membw
 %{_mandir}/man8/membw.8.gz
-{_libdir}/libpqos.so.*
+%{_libdir}/libpqos.so.*
 
 %{!?_licensedir:%global license %%doc}
 %license %{_licensedir}/%{name}-%{version}/LICENSE
-%doc ChangeLog README
+%doc ChangeLog README.md
 
 %files -n intel-cmt-cat-devel
 %{_libdir}/libpqos.so
@@ -181,6 +181,9 @@ install -m 0644 %{_builddir}/%{githubfull}/examples/c/CMT_MBM/monitor_app.c %{bu
 %doc %{_usrsrc}/%{githubfull}/LICENSE
 
 %changelog
+* Mon Dec 20 2021  Chen Guanqiao <chen.chenchacha@foxmail.com> 4.3.0-2
+- Spec file bug fixes
+
 * Thu Oct 21 2021  Michal Aleksinski <michalx.aleksinski@intel.com> 4.3.0-1
 - New release 4.3.0
 


### PR DESCRIPTION
1. macro path fomat error
2. Readme file name error

Signed-off-by: Chen Guanqiao <chen.chenchacha@foxmail.com>

This project has been unable to package out the rpm package for some time.

## Description
Fix the problem that the spec file cannot be packaged.

## Affected parts
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] library
- [ ] pqos utility
- [ ] rdtset utility
- [x] other: (please specify)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
