### PR TITLE
fix issues found with cppcheck static analysis

### DIFF
--- a/examples/c/PSEUDO_LOCK/pseudo_lock.c
+++ b/examples/c/PSEUDO_LOCK/pseudo_lock.c
@@ -81,9 +81,6 @@ init_memory(const size_t sz)
         char *p = NULL;
         size_t i;
 
-        if (sz <= 0)
-                return NULL;
-
         p = (char *)malloc(sz);
         if (p == NULL)
                 return NULL;

--- a/lib/os_cpuinfo.c
+++ b/lib/os_cpuinfo.c
@@ -157,7 +157,7 @@ cpu_online(unsigned lcore)
         unsigned online = 0;
         int retval;
 
-        snprintf(buf, sizeof(buf) - 1, SYSTEM_CPU "/cpu%d/online", lcore);
+        snprintf(buf, sizeof(buf) - 1, SYSTEM_CPU "/cpu%u/online", lcore);
         retval = fread_uint(buf, &online);
         /* online file does not exists for cpu 0 */
         if (retval == PQOS_RETVAL_RESOURCE)
@@ -184,7 +184,7 @@ cpu_node(unsigned lcore, unsigned *node)
         int count;
         int ret = PQOS_RETVAL_ERROR;
 
-        snprintf(buf, sizeof(buf) - 1, SYSTEM_CPU "/cpu%d", lcore);
+        snprintf(buf, sizeof(buf) - 1, SYSTEM_CPU "/cpu%u", lcore);
         count = scandir(buf, &namelist, filter_node, NULL);
         if (count == 1)
                 ret = parse_uint(namelist[0]->d_name + 4, node);
@@ -215,20 +215,20 @@ cpu_cache(unsigned lcore, unsigned *l3, unsigned *l2)
         int count;
         int ret = PQOS_RETVAL_ERROR;
 
-        snprintf(buf, sizeof(buf) - 1, SYSTEM_CPU "/cpu%d/cache", lcore);
+        snprintf(buf, sizeof(buf) - 1, SYSTEM_CPU "/cpu%u/cache", lcore);
         count = scandir(buf, &namelist, filter_index, NULL);
         for (i = 0; i < count; ++i) {
                 unsigned level;
                 unsigned id;
 
                 snprintf(buf, sizeof(buf) - 1,
-                         SYSTEM_CPU "/cpu%d/cache/%s/level", lcore,
+                         SYSTEM_CPU "/cpu%u/cache/%s/level", lcore,
                          namelist[i]->d_name);
                 ret = fread_uint(buf, &level);
                 if (ret != PQOS_RETVAL_OK)
                         break;
 
-                snprintf(buf, sizeof(buf) - 1, SYSTEM_CPU "/cpu%d/cache/%s/id",
+                snprintf(buf, sizeof(buf) - 1, SYSTEM_CPU "/cpu%u/cache/%s/id",
                          lcore, namelist[i]->d_name);
                 ret = fread_uint(buf, &id);
                 if (ret != PQOS_RETVAL_OK)


### PR DESCRIPTION
Fix some issues found with cppcheck static analysis. Two commits.

## Description

1. There are some printf statements using %d for an unsigned integer, use %u for these. 
2. Remove redundant less than zero check on a sizet (unsigned) variable.

## Affected parts
- [x] library
- [ ] pqos utility
- [ ] rdtset utility
- [ ] App QoS
- [x ] other:example code

## Motivation and Contex

Clean up some minor static analysis warnings. Not major bugs, just janitorial clean-ups

## How Has This Been Tested?

Just sanity checked with rebuilds with ICC and GCC and re-ran cppcheck.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Janitorial clean up

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
