### PR TITLE
Fix memory leaks on error return path and clean up to redundant assignments

### DIFF
--- a/examples/c/CAT_MBA/association_app.c
+++ b/examples/c/CAT_MBA/association_app.c
@@ -76,7 +76,7 @@ static struct {
 static void
 enforcement_get_input(int argc, char *argv[])
 {
-        int i = 0;
+        int i;
 
         if (argc < 2)
                 sel_l3ca_assoc_num = 0;

--- a/examples/c/CMT_MBM/monitor_app.c
+++ b/examples/c/CMT_MBM/monitor_app.c
@@ -333,7 +333,7 @@ monitoring_loop(void)
 {
         unsigned mon_number = 0;
         int ret = PQOS_RETVAL_OK;
-        int i = 0;
+        int i;
 
         if (signal(SIGINT, monitoring_ctrlc) == SIG_ERR)
                 printf("Failed to catch SIGINT!\n");

--- a/unit-test/pqos/caps_gen.h
+++ b/unit-test/pqos/caps_gen.h
@@ -114,8 +114,10 @@ init_cap_mon(struct test_data *data)
                 return -1;
         cap_mon->u.mon = malloc(sizeof(struct pqos_cap_mon) +
                                 num_events * sizeof(struct pqos_monitor));
-        if (cap_mon->u.mon == NULL)
+        if (cap_mon->u.mon == NULL) {
+		free(cap_mon);
                 return -1;
+	}
 
         cap_mon->type = PQOS_CAP_TYPE_MON;
         cap_mon->u.mon->mem_size = 128;
@@ -153,8 +155,10 @@ init_cap_l3ca(struct test_data *data)
         if (cap_l3ca == NULL)
                 return -1;
         cap_l3ca->u.l3ca = calloc(1, sizeof(struct pqos_cap_l3ca));
-        if (cap_l3ca->u.l3ca == NULL)
+        if (cap_l3ca->u.l3ca == NULL) {
+		free(cap_l3ca);
                 return -1;
+	}
 
         cap_l3ca->type = PQOS_CAP_TYPE_L3CA;
         cap_l3ca->u.l3ca->mem_size = 32;
@@ -179,8 +183,10 @@ init_cap_l2ca(struct test_data *data)
         if (cap_l2ca == NULL)
                 return -1;
         cap_l2ca->u.l2ca = calloc(1, sizeof(struct pqos_cap_l2ca));
-        if (cap_l2ca->u.l2ca == NULL)
+        if (cap_l2ca->u.l2ca == NULL) {
+		free(cap_l2ca);
                 return -1;
+	}
 
         cap_l2ca->type = PQOS_CAP_TYPE_L2CA;
         cap_l2ca->u.l2ca->mem_size = 32;
@@ -205,8 +211,10 @@ init_cap_mba(struct test_data *data)
         if (cap_mba == NULL)
                 return -1;
         cap_mba->u.mba = calloc(1, sizeof(struct pqos_cap_mba));
-        if (cap_mba->u.mba == NULL)
+        if (cap_mba->u.mba == NULL) {
+		free(cap_mba);
                 return -1;
+	}
 
         cap_mba->type = PQOS_CAP_TYPE_MBA;
         cap_mba->u.mba->mem_size = 28;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Clean up errors found with static analysis with cppcheck. There are some assignments that are redundant and can be removed.  Also there are 4 memory leaks in inlined functions in unit-test/pqos/caps_gen.h that are fixed. 

## Affected parts
- [ ] library
- [ ] pqos utility
- [ ] rdtset utility
- [ ] App QoS
- [x] other: unit-test and examples

## Motivation and Context
Cleans up minor issues found using static analysis

## How Has This Been Tested?
Build tested and re-tested against static analysis tools

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
