### PR TITLE
lib/os_cap.c: remove duplicated declaration of variable supported

### DIFF
--- a/lib/os_cap.c
+++ b/lib/os_cap.c
@@ -442,7 +442,6 @@ os_cap_mon_discover(struct pqos_cap_mon **r_cap, const struct pqos_cpuinfo *cpu)
         cap->l3_size = cpu->l3.total_size;
 
         for (i = 0; i < DIM(events); i++) {
-                int supported;
                 uint32_t scale;
                 struct pqos_cap_mon *mon;
                 struct pqos_monitor *monitor;


### PR DESCRIPTION
Variable supported is being declared a second time in a local scope and is name shadowing the previous declaration. The local scoped variable can be safely removed to use the outer scoped one instead.

Signed-off-by: Colin Ian King <colin.i.king@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description

cppcheck reported variable name shadowing:

<pre>lib/os_cap.c:445:21: style: Local variable &apos;supported&apos; shadows outer variable [shadowVariable]
                int supported; 
                    ^          
lib/os_cap.c:403:13: note: Shadowed declaration
        int supported;
            ^            
lib/os_cap.c:445:21: note: Shadow variable
                int supported; 
</pre>

Remove local scoped declaration, this is OK because the variable is never used afterwards.

## Affected parts
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] library
- [ ] pqos utility
- [ ] rdtset utility
- [ ] App QoS
- [ ] other: (please specify)

## Motivation and Context

Cleans up a cppcheck warning. No functional changes.

## How Has This Been Tested?

Build tested only

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
