### PR TITLE
lib/cpuinfo: Increase the file descriptors limit to handle more CPUs

### DIFF
--- a/lib/common.h
+++ b/lib/common.h
@@ -200,6 +200,17 @@ PQOS_LOCAL void pqos_munmap(void *mem, const uint64_t size);
  */
 PQOS_LOCAL ssize_t pqos_read(int fd, void *buf, size_t count);
 
+/**
+ * @brief Increase the number of open files limit to handle more
+ * than 256 CPUs.
+ *
+ * @param [in] Max CPUs on the system
+ *
+ * @return PQOS_RETVAL_OK for success
+ * @retval PQOS_RETVAL_ERROR for failure
+ */
+PQOS_LOCAL int pqos_set_no_files_limit(unsigned long max_core_count);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/cpuinfo.c
+++ b/lib/cpuinfo.c
@@ -39,6 +39,7 @@
 
 #include "allocation.h"
 #include "cap.h"
+#include "common.h"
 #include "cpu_registers.h"
 #include "log.h"
 #include "machine.h"
@@ -57,6 +58,7 @@
 #endif
 #ifdef __linux__
 #include <sched.h> /* sched affinity */
+#include <sys/resource.h>
 #include <sys/syscall.h>
 #endif
 
@@ -449,6 +451,11 @@ cpuinfo_build_topo(struct apic_info *apic)
         max_core_count = sysconf(_SC_NPROCESSORS_CONF);
         if (max_core_count <= 0) {
                 LOG_ERROR("Zero processors in the system!");
+                return NULL;
+        }
+
+        if (pqos_set_no_files_limit(max_core_count)) {
+                LOG_ERROR("Open files limit not sufficient!\n");
                 return NULL;
         }
 

--- a/lib/os_cpuinfo.c
+++ b/lib/os_cpuinfo.c
@@ -43,6 +43,7 @@
 #include <limits.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/resource.h>
 
 #define SYSTEM_CPU  "/sys/devices/system/cpu"
 #define SYSTEM_NODE "/sys/devices/system/node"
@@ -264,6 +265,11 @@ os_cpuinfo_topology(void)
                 return NULL;
         } else if (max_core_count == 0) {
                 LOG_ERROR("Zero processors in the system!\n");
+                return NULL;
+        }
+
+        if (pqos_set_no_files_limit(max_core_count)) {
+                LOG_ERROR("Open files limit not sufficient!\n");
                 return NULL;
         }
 

--- a/pqos/alloc.c
+++ b/pqos/alloc.c
@@ -840,7 +840,7 @@ set_allocation_assoc(const struct pqos_devinfo *dev)
 static void
 fill_core_tab(char *str)
 {
-        unsigned max_cores_count = 128;
+        unsigned max_cores_count = sysconf(_SC_NPROCESSORS_CONF);
         uint64_t *cores = calloc(max_cores_count, sizeof(uint64_t));
         unsigned i = 0, n = 0, cos = 0;
         char *p = NULL;


### PR DESCRIPTION
The pqos tool fails with the following errors on systems with 300 or more CPU cores.
$pqos
NOTE:  Mixed use of MSR and kernel interfaces to manage
       CAT or CMT & MBM may lead to unexpected behavior.
ERROR: Could not open /sys/fs/resctrl directory
ERROR: Failed to stop resctrl events
ERROR: Failed to start all selected OS monitoring events Monitoring start error on core(s) 339, status 1

By default, the file descriptor limit is set to 1024 for a session. pqos monitor uses 3 descriptors for each CPU for perf monitoring. So, it runs out of limit(1024) on systems with 300 or more CPUs.

Fix the issue by detecting the number of CPUs in the system and increasing the descriptor limit using system call getrlimit and setrlimit respectively. Increase the limit to 4 times the number of CPUs to take care of open files limit.

<!--- Provide a general summary of your changes in the Title above -->

## Description
By default, the file descriptor limit is set to 1024 for a session. pqos
monitor uses 3 descriptors for each CPU for perf monitoring. So, it runs
out of limit(1024) on systems with 300 or more CPUs.

Fix the issue by detecting the number of CPUs in the system and increasing
the descriptor limit using system call getrlimit and setrlimit respectively.
Increase the limit to 4 times the number of CPUs to take care of open files
limit.

## Affected parts
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] library
- [x] pqos utility
- [ ] rdtset utility
- [ ] App QoS
- [ ] other: (please specify)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Tested on AMD system.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
