### PR TITLE
Remove fcf-protection=full

### DIFF
--- a/examples/c/CAT_MBA/Makefile
+++ b/examples/c/CAT_MBA/Makefile
@@ -63,8 +63,7 @@ IS_GCC = $(shell $(CC) -v 2>&1 | grep -c "^gcc version ")
 ifeq ($(IS_GCC),1)
 CFLAGS += -fno-strict-overflow \
     -fno-delete-null-pointer-checks \
-    -fwrapv \
-    -fcf-protection=full
+    -fwrapv
 endif
 
 # Build targets and dependencies

--- a/examples/c/CMT_MBM/Makefile
+++ b/examples/c/CMT_MBM/Makefile
@@ -63,8 +63,7 @@ IS_GCC = $(shell $(CC) -v 2>&1 | grep -c "^gcc version ")
 ifeq ($(IS_GCC),1)
 CFLAGS += -fno-strict-overflow \
     -fno-delete-null-pointer-checks \
-    -fwrapv \
-    -fcf-protection=full
+    -fwrapv
 endif
 
 # Build targets and dependencies

--- a/examples/c/PSEUDO_LOCK/Makefile
+++ b/examples/c/PSEUDO_LOCK/Makefile
@@ -63,8 +63,7 @@ IS_GCC = $(shell $(CC) -v 2>&1 | grep -c "^gcc version ")
 ifeq ($(IS_GCC),1)
 CFLAGS += -fno-strict-overflow \
     -fno-delete-null-pointer-checks \
-    -fwrapv \
-    -fcf-protection=full
+    -fwrapv
 endif
 
 # Build targets and dependencies

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -72,8 +72,7 @@ ifeq ($(IS_GCC),1)
 CFLAGS += -fno-strict-overflow \
     -fno-delete-null-pointer-checks \
     -fwrapv \
-    -fstack-protector-strong \
-    -fcf-protection=full
+    -fstack-protector-strong
 endif
 
 # so or static build

--- a/pqos/Makefile
+++ b/pqos/Makefile
@@ -45,8 +45,7 @@ CFLAGS = -I$(LIBDIR) \
 	-Wmissing-declarations -Wold-style-definition -Wpointer-arith \
 	-Wcast-qual -Wundef -Wwrite-strings \
 	-Wformat -Wformat-security -fstack-protector -fPIE \
-	-Wunreachable-code -Wsign-compare -Wno-endif-labels \
-	-fcf-protection=full
+	-Wunreachable-code -Wsign-compare -Wno-endif-labels
 ifneq ($(EXTRA_CFLAGS),)
 CFLAGS += $(EXTRA_CFLAGS)
 endif
@@ -70,8 +69,7 @@ ifeq ($(IS_GCC),1)
 CFLAGS += -fno-strict-overflow \
     -fno-delete-null-pointer-checks \
     -fwrapv \
-    -fstack-protector-strong \
-    -fcf-protection=full
+    -fstack-protector-strong
 endif
 
 ifeq ($(shell uname), FreeBSD)

--- a/rdtset/Makefile
+++ b/rdtset/Makefile
@@ -45,8 +45,7 @@ CFLAGS = -I$(LIBDIR) \
 	-Wcast-qual -Wundef -Wwrite-strings \
 	-Wformat -Wformat-security -fstack-protector -fPIE \
 	-Wunreachable-code -Wsign-compare -Wno-endif-labels \
-	-D_GNU_SOURCE \
-	-fcf-protection=full
+	-D_GNU_SOURCE
 ifneq ($(EXTRA_CFLAGS),)
 CFLAGS += $(EXTRA_CFLAGS)
 endif
@@ -70,8 +69,7 @@ ifeq ($(IS_GCC),1)
 CFLAGS += -fno-strict-overflow \
 	-fno-delete-null-pointer-checks \
 	-fwrapv \
-	-fstack-protector-strong \
-	-fcf-protection=full
+	-fstack-protector-strong
 endif
 
 # DEBUG build

--- a/tools/membw/Makefile
+++ b/tools/membw/Makefile
@@ -49,8 +49,7 @@ CFLAGS=-W -Wall -Wextra -Wstrict-prototypes -Wmissing-prototypes \
 	-Wcast-qual -Wundef -Wwrite-strings \
 	-Wformat -Wformat-security -fstack-protector -fPIE \
 	-Wunreachable-code -Wsign-compare -Wno-endif-labels \
-	-Winline -msse4.2 \
-	-fcf-protection=full
+	-Winline -msse4.2
 
 ifeq ($(DEBUG),y)
 CFLAGS += -O0 -g -DDEBUG
@@ -77,8 +76,7 @@ CFLAGS += -fno-strict-overflow \
     -fno-delete-null-pointer-checks \
     -fwrapv \
     -fno-expensive-optimizations \
-    -fstack-protector-strong \
-    -fcf-protection=full
+    -fstack-protector-strong
 endif
 
 SRCS = $(sort $(wildcard *.c))

--- a/unit-test/lib/Makefile
+++ b/unit-test/lib/Makefile
@@ -34,8 +34,7 @@ ifeq ($(IS_GCC),1)
 CFLAGS += -fno-strict-overflow \
 	-fno-delete-null-pointer-checks \
 	-fwrapv \
-	-fstack-protector-strong \
-	-fcf-protection=full
+	-fstack-protector-strong
 endif
 
 # common function wrap

--- a/unit-test/mock/Makefile
+++ b/unit-test/mock/Makefile
@@ -68,8 +68,7 @@ IS_GCC = $(shell $(CC) -v 2>&1 | grep -c "^gcc version ")
 ifeq ($(IS_GCC),1)
 CFLAGS += -fno-strict-overflow \
     -fno-delete-null-pointer-checks \
-    -fwrapv \
-    -fcf-protection=full
+    -fwrapv
 endif
 
 # so or static build

--- a/unit-test/output/Makefile
+++ b/unit-test/output/Makefile
@@ -65,8 +65,7 @@ IS_GCC = $(shell $(CC) -v 2>&1 | grep -c "^gcc version ")
 ifeq ($(IS_GCC),1)
 CFLAGS += -fno-strict-overflow \
     -fno-delete-null-pointer-checks \
-    -fwrapv \
-    -fcf-protection=full
+    -fwrapv
 endif
 
 # so or static build

--- a/unit-test/pqos/Makefile
+++ b/unit-test/pqos/Makefile
@@ -69,8 +69,7 @@ ifeq ($(IS_GCC),1)
 CFLAGS += -fno-strict-overflow \
     -fno-delete-null-pointer-checks \
     -fwrapv \
-    -fstack-protector-strong \
-    -fcf-protection=full
+    -fstack-protector-strong
 endif
 
 CFLAGS += -g -ggdb -O0


### PR DESCRIPTION
This option causes grief with at least some gcc versions:

built failure ->"cc: error: unrecognized command line option '-fcf- protection=full'; did you mean '-fstack-protector-all'?"

and some archs (i586):

 cc1: error: ‘-fcf-protection’ is not compatible with this target

According to our gcc maintainer (translated):
Whatever the reason is that they require gcc version 9..., maybe  -fcf-protection, but simply throw it out...

If there is no urgent reason, better get rid of this one.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Affected parts
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] library
- [ ] pqos utility
- [ ] rdtset utility
- [ ] App QoS
- [ ] other: (please specify)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
