### PR TITLE
Minor fixes in pqos_read() implementation

### DIFF
--- a/lib/common.c
+++ b/lib/common.c
@@ -382,8 +382,10 @@ pqos_read(int fd, void *buf, size_t count)
         char *byte_ptr = (char *)buf;
         ssize_t ret;
 
-        if (buf == NULL)
+        if (buf == NULL) {
+                errno = EFAULT;
                 return -1;
+        }
 
         while (len != 0 && (ret = read(fd, byte_ptr, len)) != 0) {
                 if (ret == -1) {

--- a/lib/common.c
+++ b/lib/common.c
@@ -378,9 +378,9 @@ pqos_munmap(void *mem, const uint64_t size)
 ssize_t
 pqos_read(int fd, void *buf, size_t count)
 {
-        int len = count;
+        size_t len = count;
         char *byte_ptr = (char *)buf;
-        int ret;
+        ssize_t ret;
 
         if (buf == NULL)
                 return -1;


### PR DESCRIPTION
This series contains two patches that provide minor fixes to pqos_read() function.

## Description
This patch series is a result of a static analysis report that pointed out an issue within pqos_read() function implementation, specifically, a possible integer overflow.  Upon review of the implementation, it was also identified that there's a minor issue (a missing errno update) when function returns early in the failed NULL check of the buf pointer.

## Affected parts
- [x] library
- [ ] pqos utility
- [ ] rdtset utility
- [ ] App QoS
- [ ] other: (please specify)

## Motivation and Context
This series fixes an issue reported by static analysis, so it no longer exists.

## How Has This Been Tested?
No specific tests have been implemented beside a small program that reads 4G+4 bytes from /dev/zero and stracing it to check the behaviour:
```
pts/12, esyr@nurgle: ~/dev/intel-cmt-cat/lib % cat test.c
#include <fcntl.h>
#include <stdio.h>
#include <stdlib.h>
#include <sys/types.h>
#include <sys/stat.h>

#include "common.h"

int main(void)
{
	const size_t count = (1ULL << 32) + 4;
	void *buf;
	ssize_t ret;
	int fd;


	buf = malloc(count);
	if (!buf) {
		perror("malloc");
		return 1;
	}

	fd = open("/dev/zero", O_RDONLY);
	if (fd < 0) {
		perror("open");
		return 2;
	}

	ret = pqos_read(fd, NULL, count);
	if (ret < 0)
		perror("pqos_read");

	ret = pqos_read(fd, buf, count);
	if (ret < 0)
		perror("pqos_read");
	printf("pqos_read result: %zd\n", ret);

	return 0;
}
pts/12, esyr@nurgle: ~/dev/intel-cmt-cat/lib % gcc -c test.c -o test.o          
pts/12, esyr@nurgle: ~/dev/intel-cmt-cat/lib % gcc common.o log.o test.o -o test
pts/12, esyr@nurgle: ~/dev/intel-cmt-cat/lib % strace -y -e read -P/dev/zero ./test
pqos_read: Bad address
read(3</dev/zero>, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"..., 4294967300) = 2147479552
read(3</dev/zero>, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"..., 2147487748) = 2147479552
read(3</dev/zero>, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"..., 8196) = 8196
pqos_read result: 4294967300
+++ exited with 0 +++
pts/12, esyr@nurgle: ~/dev/intel-cmt-cat/lib % git checkout origin/master
[...]
pts/12, esyr@nurgle: ~/dev/intel-cmt-cat/lib % make common.o
[...]
pts/12, esyr@nurgle: ~/dev/intel-cmt-cat/lib % gcc common.o log.o test.o -o test
pts/12, esyr@nurgle: ~/dev/intel-cmt-cat/lib % strace -y -e read -P/dev/zero ./test
pqos_read: Success                             
read(3</dev/zero>, "\0\0\0\0", 4)       = 4
pqos_read result: 4294967300
+++ exited with 0 +++
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
