### PR TITLE
Fix incorrect bitmask for MBM counter length

### DIFF
--- a/lib/hw_cap.c
+++ b/lib/hw_cap.c
@@ -436,7 +436,7 @@ hw_cap_mon_discover(struct pqos_cap_mon **r_mon, const struct pqos_cpuinfo *cpu)
         {
                 const unsigned max_rmid = cpuid_0xf_1.ecx + 1;
                 const uint32_t scale_factor = cpuid_0xf_1.ebx;
-                const unsigned counter_length = (cpuid_0xf_1.eax & 0x7f) + 24;
+                const unsigned counter_length = (cpuid_0xf_1.eax & 0xff) + 24;
 
                 if (cpuid_0xf_1.edx & PQOS_CPUID_MON_L3_OCCUP_BIT) {
                         int iordt =


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
From Intel RDT spec[1] and AMD Platform QoS spec[2]: If the CPU platform supports CPUID.0FH.01H:EAX, CPUID.0FH.01H:EAX[7:0] returns MBM counter length (width) as offset from 24.

But in hw_cap_mon_discover(), the MBM counter length is calculated with incorrect 7-bits bitmask (0x7f).

Fix the issue with 8-bits bitmask (0xff) for MBM counter length.

[1] Intel Architectures SDM, Vol.3B, 19.18 Intel RDT Monitoring: https://cdrdv2.intel.com/v1/dl/getContent/671200

[2] AMD Platform QoS Extensions, Rev 1.03:
https://www.amd.com/content/dam/amd/en/documents/processor-tech-docs/other/56375_1_03_PUB.pdf

Fixes: 050f8c64ad9d ("lib: detect MBM counter length")

## Affected parts
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] library
- [ ] pqos utility
- [ ] rdtset utility
- [ ] other: (please specify)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix incorrect bitmask for MBM counter length

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
1. Passed all tests in intel-cmt-cat/unit-test.
2. Run most pqos tests described below:
https://github.com/intel/intel-cmt-cat/wiki/Usage-Examples

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
