### PR TITLE
Fix CPU detection in cgroup v2 constrained environments

### DIFF
--- a/lib/os_cpuinfo.c
+++ b/lib/os_cpuinfo.c
@@ -253,62 +253,68 @@ os_cpuinfo_topology(void)
 {
         struct pqos_cpuinfo *cpu = NULL;
         struct dirent **namelist = NULL;
-        int max_core_count;
         int num_cpus;
         int i;
         int retval = PQOS_RETVAL_OK;
 
-        max_core_count = sysconf(_SC_NPROCESSORS_CONF);
-        if (max_core_count < 0) {
-                LOG_ERROR("Failed to get number of processors!\n");
-                return NULL;
-        } else if (max_core_count == 0) {
-                LOG_ERROR("Zero processors in the system!\n");
+        num_cpus = scandir(SYSTEM_CPU, &namelist, filter_cpu, cpu_sort);
+
+        if (num_cpus <= 0) {
+                LOG_ERROR("os_cpuinfo_topology: Failed to read %s!\n", SYSTEM_CPU);
+                if (namelist != NULL)
+                        free(namelist);
                 return NULL;
         }
 
-        if (pqos_set_no_files_limit(max_core_count)) {
+        if (pqos_set_no_files_limit(num_cpus)) {
                 LOG_ERROR("Open files limit not sufficient!\n");
+                for (i = 0; i < num_cpus; i++)
+                        free(namelist[i]);
+                free(namelist);
                 return NULL;
         }
 
         const size_t mem_sz =
-            sizeof(*cpu) + (max_core_count * sizeof(struct pqos_coreinfo));
+            sizeof(*cpu) + (num_cpus * sizeof(struct pqos_coreinfo));
 
         cpu = (struct pqos_cpuinfo *)malloc(mem_sz);
         if (cpu == NULL) {
                 LOG_ERROR("Couldn't allocate CPU topology structure!\n");
+                for (i = 0; i < num_cpus; i++)
+                        free(namelist[i]);
+                free(namelist);
                 return NULL;
         }
         cpu->mem_size = (unsigned)mem_sz;
         memset(cpu, 0, mem_sz);
 
-        num_cpus = scandir(SYSTEM_CPU, &namelist, filter_cpu, cpu_sort);
-        if (num_cpus <= 0 || max_core_count < num_cpus) {
-                LOG_ERROR("Failed to read proc cpus!\n");
-                free(cpu);
-                return NULL;
-        }
-
         for (i = 0; i < num_cpus; i++) {
                 unsigned lcore = atoi(namelist[i]->d_name + 3);
                 struct pqos_coreinfo *info = &cpu->cores[cpu->num_cores];
 
-                if (!os_cpuinfo_cpu_online(lcore))
+                if (!os_cpuinfo_cpu_online(lcore)) {
+                        LOG_DEBUG("Logical core %u is offline, skipping\n", lcore);
                         continue;
+                }
 
                 retval = os_cpuinfo_cpu_socket(lcore, &info->socket);
-                if (retval != PQOS_RETVAL_OK)
+                if (retval != PQOS_RETVAL_OK) {
+                        LOG_ERROR("Failed to get socket for lcore %u\n", lcore);
                         break;
+                }
 
                 retval = os_cpuinfo_cpu_node(lcore, &info->numa);
-                if (retval != PQOS_RETVAL_OK)
+                if (retval != PQOS_RETVAL_OK) {
+                        LOG_ERROR("Failed to get NUMA node for lcore %u\n", lcore);
                         break;
+                }
 
                 retval =
                     os_cpuinfo_cpu_cache(lcore, &info->l3_id, &info->l2_id);
-                if (retval != PQOS_RETVAL_OK)
+                if (retval != PQOS_RETVAL_OK) {
+                        LOG_ERROR("Failed to get cache IDs for lcore %u\n", lcore);
                         break;
+                }
 
                 info->lcore = lcore;
 
@@ -362,25 +368,21 @@ int
 os_cpuinfo_get_socket_num(void)
 {
         struct dirent **namelist = NULL;
-        int max_core_count;
         int num_cpus;
         unsigned num_sockets = 0;
         unsigned *sockets;
         int i;
         int retval = PQOS_RETVAL_OK;
 
-        max_core_count = sysconf(_SC_NPROCESSORS_CONF);
-        if (max_core_count < 0) {
-                LOG_ERROR("Failed to get number of processors!\n");
-                return -1;
-        } else if (max_core_count == 0) {
+        num_cpus = scandir(SYSTEM_CPU, &namelist, filter_cpu, cpu_sort);
+
+        if (num_cpus == 0) {
                 LOG_ERROR("Zero processors in the system!\n");
                 return -1;
         }
 
-        num_cpus = scandir(SYSTEM_CPU, &namelist, filter_cpu, cpu_sort);
-        if (num_cpus <= 0 || max_core_count < num_cpus) {
-                LOG_ERROR("Failed to read proc cpus!\n");
+        if (num_cpus <= 0) {
+                LOG_ERROR("os_cpuinfo_get_socket_num: Failed to read %s cpus!\n", SYSTEM_CPU);
                 return -1;
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Remove sysconf(_SC_NPROCESSORS_CONF) validation that causes false failures when the library runs in a process with cgroup v2 CPU limits.

When cpu.max is set in cgroup v2, sysconf(_SC_NPROCESSORS_CONF) returns the cgroup-limited CPU count rather than the actual system CPU count. However, scanning /sys/devices/system/cpu always returns the real number of cores in the system, causing a mismatch and spurious check failures.

By removing the sysconf() call and relying solely on the sysfs scan, we ensure consistent CPU topology detection regardless of cgroup constraints.

## Affected parts
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] library
- [ ] pqos utility
- [ ] rdtset utility
- [ ] other: (please specify)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

https://github.com/lf-edge/eve uses libpqos from privileged system container  pkg/pillar. This is a houskeeping conitainer that creates user workloads and it is restricted only to core 0 but has full visibility of /sys/fs so the library did not initilize

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

This was tested from EVE OS on a real device with intel RDT support 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
