### PR TITLE
Fix SNC state detection on non-SNC-capable platforms

### DIFF
--- a/lib/hw_cap.c
+++ b/lib/hw_cap.c
@@ -237,6 +237,19 @@ hw_cap_mon_snc_state(const struct pqos_cpuinfo *cpu,
 
         if (numa_num < 0 || socket_num < 0)
                 return PQOS_RETVAL_ERROR;
+
+        /**
+         * On platforms that do not support Sub-NUMA Clustering (SNC)
+         * monitoring (e.g., AMD and Hygon platforms).
+         *
+         * Set snc_num = 1 and return early.
+         */
+        if (cpu->vendor == PQOS_VENDOR_AMD ||
+            cpu->vendor == PQOS_VENDOR_HYGON) {
+                *snc_num = 1;
+                return PQOS_RETVAL_OK;
+        }
+
         if (numa_num == 0 || socket_num == 0 || numa_num == socket_num) {
                 *snc_num = 1;
                 *snc_mode = PQOS_SNC_LOCAL;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix SNC state detection on non-SNC-capable platforms

## Description
<!--- Describe your changes in detail -->
On platforms that do not support Sub-NUMA Clustering (SNC) monitoring (e.g., AMD and Hygon), if the CPU topology indicates that the number of NUMA nodes and the number of sockets are not equal, the SNC state detection logic in hw_cap_mon_snc_state() will attempt to read the SNC configuration MSR register PQOS_MSR_SNC_CFG (0xCA0) that is not
available. This causes the command "pqos --iface=msr" to fail with the error:

```
ERROR: RDMSR failed for reg[0xca0] on lcore 0
ERROR: Error reading SNC information!
ERROR: Error encounter in monitoring discovery!
ERROR: discover_capabilities() error 1
Error initializing PQoS library!
```

Fix the issue by ensuring hw_cap_mon_snc_state() returns early on non-SNC-capable platforms.

## Affected parts
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] library
- [ ] pqos utility
- [ ] rdtset utility
- [ ] other: (please specify)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The command "pqos --iface=msr" fails on non-SNC-capable platforms during SNC state detection with the error:

```
ERROR: RDMSR failed for reg[0xca0] on lcore 0
ERROR: Error reading SNC information!
ERROR: Error encounter in monitoring discovery!
ERROR: discover_capabilities() error 1
Error initializing PQoS library!
```

The code changes fix the issue on non-SNC-capable platforms.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
(1) Run "pqos --iface=msr" without the error described above on non-SNC-capable platforms (e.g., AMD or Hygon).
(2) Passed all tests in intel-cmt-cat/unit-test.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
