### PR TITLE
Show L3CA/MBA COS definitions per L3 cluster on AMD and Hygon

### DIFF
--- a/lib/pqos.h
+++ b/lib/pqos.h
@@ -1838,6 +1838,18 @@ unsigned *pqos_cpu_get_numa(const struct pqos_cpuinfo *cpu, unsigned *count);
 unsigned *pqos_cpu_get_l2ids(const struct pqos_cpuinfo *cpu, unsigned *count);
 
 /**
+ * @brief Retrieves L3 cluster id's from cpu info structure
+ *
+ * @param [in] cpu CPU information structure from \a pqos_cap_get
+ * @param [out] count place to store actual number of L3 cluster id's returned
+ *
+ * @return Allocated array of size \a count populated with L3 cluster id's
+ * @retval NULL on error
+ */
+unsigned *pqos_cpu_get_l3_clusters(const struct pqos_cpuinfo *cpu,
+                                   unsigned *count);
+
+/**
  * @brief Creates list of cores belonging to given L3 cluster
  *
  * Function allocates memory for the core list that needs to be freed by

--- a/lib/utils.c
+++ b/lib/utils.c
@@ -276,6 +276,45 @@ pqos_cpu_get_l2ids(const struct pqos_cpuinfo *cpu, unsigned *count)
         return l2ids;
 }
 
+unsigned *
+pqos_cpu_get_l3_clusters(const struct pqos_cpuinfo *cpu, unsigned *count)
+{
+        unsigned l3c_count = 0, i = 0;
+        unsigned *l3_clusters = NULL;
+
+        ASSERT(cpu != NULL);
+        ASSERT(count != NULL);
+        if (cpu == NULL || count == NULL)
+                return NULL;
+
+        l3_clusters =
+            (unsigned *)malloc(sizeof(l3_clusters[0]) * cpu->num_cores);
+
+        if (l3_clusters == NULL)
+                return NULL;
+
+        for (i = 0; i < cpu->num_cores; i++) {
+                unsigned j = 0;
+
+                /**
+                 * Check if this L3 id is already on the \a l3_clusters list
+                 */
+                for (j = 0; j < l3c_count && l3c_count > 0; j++)
+                        if (cpu->cores[i].l3_id == l3_clusters[j])
+                                break;
+
+                if (j >= l3c_count || l3c_count == 0) {
+                        /**
+                         * This l3_id wasn't reported before
+                         */
+                        l3_clusters[l3c_count++] = cpu->cores[i].l3_id;
+                }
+        }
+
+        *count = l3c_count;
+        return l3_clusters;
+}
+
 /**
  * @brief Creates list of cores belonging to given topology object
  *


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Show L3CA/MBA COS definitions per L3 cluster on AMD and Hygon

## Description
<!--- Describe your changes in detail -->
This PR adds 3 patches (2 preparatory patches) to support showing L3CA/MBA COS definitions per L3 cluster instead of per socket on AMD and Hygon platforms that Platform QoS allocation configuration is per L3 cluster (or Core Complex - CCX).

The output of "pqos -s" looks like:

```
$ pqos -s
L3CA/MBA COS definitions for L3 Cluster (or Core Complex) 0:
    L3CA COS0 => MASK 0xffff
    ...
    L3CA COS15 => MASK 0xffff
    MBA COS0 => 2048 available
    ...
    MBA COS15 => 2048 available
L3CA/MBA COS definitions for L3 Cluster (or Core Complex) N:
...
```

Xiaochen Shen (3):
  lib: Introduce pqos_cpu_get_l3_clusters
  pqos: Introduce print_per_l3_cluster_config
  pqos: Show L3CA/MBA COS definitions per L3 cluster on AMD and Hygon

## Affected parts
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] library
- [x] pqos utility
- [ ] rdtset utility
- [ ] other: (please specify)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
AMD and Hygon Platform QoS allocation configuration is per L3 cluster (or Core Complex - CCX). Each L3 cluster (CCX) has one L3 cluster ID which is used for both CAT and MBA ids.

Show L3CA/MBA COS definitions per L3 cluster instead of per socket on AMD and Hygon platforms. The output of "pqos -s" looks like:

```
$ pqos -s
L3CA/MBA COS definitions for L3 Cluster (or Core Complex) 0:
    L3CA COS0 => MASK 0xffff
    ...
    L3CA COS15 => MASK 0xffff
    MBA COS0 => 2048 available
    ...
    MBA COS15 => 2048 available
L3CA/MBA COS definitions for L3 Cluster (or Core Complex) N:
...
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
(1) The output of "pqos -s" shows "L3CA/MBA COS definitions for L3 Cluster (or Core Complex) N" on AMD or Hygon platforms.
(2) Passed all tests in intel-cmt-cat/unit-test.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
