### PR TITLE
lib: don't fall back to /dev/mem for ACPI tables exposed via sysfs

### DIFF
--- a/lib/acpi.c
+++ b/lib/acpi.c
@@ -473,6 +473,20 @@ acpi_get_sig(const char *sig)
                         return tbl;
         }
 
+        /*
+         * The kernel exposes every ACPI table listed in the RSDT/XSDT under
+         * /sys/firmware/acpi/tables, whether or not the kernel supports it.
+         * So once that directory exists, a table that cannot be obtained from
+         * it - absent, or present but unreadable/invalid - will not be found
+         * by scanning physical memory either, so skip the /dev/mem scan.
+         */
+        if (pqos_dir_exists(ACPI_TABLE_FS_PATH)) {
+                LOG_DEBUG("ACPI table %s not available via sysfs; "
+                          "skipping memory scan\n",
+                          sig);
+                return NULL;
+        }
+
         LOG_DEBUG("Trying to obtain %s acpi table from ACPI memory\n", sig);
         return acpi_get_mmap(sig);
 }


### PR DESCRIPTION
## Problem

Closes #307.

On kernels built with `CONFIG_STRICT_DEVMEM=y`, initializing libpqos (or running the `pqos` CLI) emits:

```
ERROR: Memory map failed, address=... size=...
ERROR: Memory mapping failed!
ERROR: Failed to obtain RSDP table!
WARN: Could not obtain ERDT table
```

`acpi_get_sig()` first looks for a table under `/sys/firmware/acpi/tables/`, and if it is not there falls back to `acpi_get_mmap()`, which opens `/dev/mem` and maps/reads physical memory (RSDP/BIOS region). `CONFIG_STRICT_DEVMEM=y` restricts `/dev/mem`, so the mmap fails — or, for the low-BIOS scan region, the mmap can *succeed* and the subsequent read faults. For a library caller this is worse than log noise: a fault in this path takes down the process (e.g. a CGO host such as the Go bindings).

## Why the memory fallback is unnecessary here

The kernel exposes **every** ACPI table advertised in the RSDT/XSDT under `/sys/firmware/acpi/tables/`, keyed by signature, regardless of whether the kernel has a driver for it (`drivers/acpi/sysfs.c` walks `acpi_gbl_root_table_list` with no signature filtering). Therefore:

- If ERDT/MRRM/IRDT exist, firmware lists them in the XSDT and they are already present in sysfs — no `/dev/mem` needed.
- If they are not in sysfs, they are not obtainable from `/dev/mem` either — the fallback finds nothing and only risks the strict-devmem fault.

The fallback is only meaningful on legacy kernels that do not expose `/sys/firmware/acpi/tables/` at all.

## Fix

In `acpi_get_sig()`, when `/sys/firmware/acpi/tables/` exists but the requested table is not present there, return `NULL` instead of scanning `/dev/mem`. The memory fallback is preserved for kernels that do not expose that directory.

## Test

- `make -C lib` builds clean (no new warnings; `acpi_get_mmap` is still referenced for the legacy path).
- On a `CONFIG_STRICT_DEVMEM=y` host where `/sys/firmware/acpi/tables/` exists without an `ERDT` entry, init no longer touches `/dev/mem` and the errors above are gone.