### PR TITLE
lib: Fix double free issues in amd_cap_mba_discover() and amd_cap_smba_discover()

### DIFF
--- a/lib/hw_cap.c
+++ b/lib/hw_cap.c
@@ -1302,7 +1302,6 @@ amd_cap_mba_discover(struct pqos_cap_mba *cap, const struct pqos_cpuinfo *cpu)
         lcpuid(0x80000008, 0x0, &res);
         if (!(res.ebx & (1 << 6))) {
                 LOG_INFO("CPUID.0x80000008.0: MBA not supported\n");
-                free(cap);
                 return PQOS_RETVAL_RESOURCE;
         }
 
@@ -1312,7 +1311,6 @@ amd_cap_mba_discover(struct pqos_cap_mba *cap, const struct pqos_cpuinfo *cpu)
         lcpuid(0x80000020, 0x0, &res);
         if (!(res.ebx & (1 << 1))) {
                 LOG_INFO("CPUID 0x10.0: MBA not supported!\n");
-                free(cap);
                 return PQOS_RETVAL_RESOURCE;
         }
 

--- a/lib/hw_cap.c
+++ b/lib/hw_cap.c
@@ -1345,7 +1345,6 @@ amd_cap_smba_discover(struct pqos_cap_mba *cap, const struct pqos_cpuinfo *cpu)
         lcpuid(0x80000020, 0x0, &res);
         if (!(res.ebx & (1 << 2))) {
                 LOG_INFO("CPUID.0x80000008.0: SMBA not supported\n");
-                free(cap);
                 return PQOS_RETVAL_RESOURCE;
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In the call path cap_mba_discover() -> amd_cap_mba_discover() / cap_smba_discover() -> amd_cap_smba_discover(), a double-free issue is triggered when cpuid(0x80000008.0) or cpuid(0x80000020.0) fails. On error, amd_cap_mba_discover() / amd_cap_smba_discover() calls free(cap) and returns, but the caller, cap_mba_discover() / cap_smba_discover(), subsequently calls free(cap) again.

Fix this by removing the redundant free(cap) calls from amd_cap_mba_discover() and amd_cap_smba_discover().

Fixes: 1618ce1a3b08 ("lib: Discover SMBA feature using cpuid method")
Fixes: 20f07095f4e0 ("lib: moved HW AMD detection of MBA to hw_cap module")
Fixes: 72beceac50df ("lib: Introduce new function discover_alloc_mba_amd for AMD")

## Affected parts
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] library
- [ ] pqos utility
- [ ] other: (please specify)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix double free issues in amd_cap_mba_discover() and amd_cap_smba_discover().

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Command "pqos"  fails with errors on platforms that hit this failure path (e.g., Hygon C86-4G 7490):
```
$ pqos -s
Selected interface: MSR
WARN: CPUID.0x7.0: Monitoring capability not supported!
WARN: Cache allocation not supported on model name 'Hygon C86-4G (OPN:7490)'!
free(): double free detected in tcache 2
Aborted
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
